### PR TITLE
添加文章置顶功能，quest与simple主题中新增置顶样式

### DIFF
--- a/app/controllers/Gitblog.php
+++ b/app/controllers/Gitblog.php
@@ -368,7 +368,6 @@ class Gitblog extends CI_Controller {
 		$pageBarSize = $this->confObj['blog']['pageBarSize'];
 		
 		$pages = $this->markdown->getTotalPages($pageSize);
-		
 		if ($pageNo <= 0) {
 			$pageNo = 1;
 		}
@@ -376,8 +375,8 @@ class Gitblog extends CI_Controller {
 		if ($pageNo > $pages) {
 			$pageNo = $pages;
 		}
-		
 		$pageData = $this->markdown->getBlogsByPage($pageNo, $pageSize);
+		
 		$pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize);
 		$this->setData("pagination", $pagination);
 		

--- a/app/libraries/Markdown.php
+++ b/app/libraries/Markdown.php
@@ -333,7 +333,7 @@ class Markdown {
 		$noteBlockArr = array();
 		$noteTmpArr = array();
 		$pattern1 = '/<\!\-\-(.*?)\-\->/is';
-		$pattern2 = '/^\s*(author|head|date|title|summary|images|tags|category|status)\s*:(.*?)$/im';
+		$pattern2 = '/^\s*(author|head|date|title|top|summary|images|tags|category|status)\s*:(.*?)$/im';
 	    
 		$subject = file_get_contents($serverPath);
 	    
@@ -344,6 +344,7 @@ class Markdown {
 			"title" => "",
 			"summary" => "",
 			"keywords" => "",
+			"top" => "0",
 			"images" => array(),
 			"tags" => array(),
 			"category" => array(),
@@ -378,6 +379,9 @@ class Markdown {
 								break;
 							case "title":
 								$blogProp['title'] = $propVal;
+								break;
+							case "top":
+								$blogProp['top'] = $propVal;
 								break;
 							case "summary":
 								$blogProp['summary'] = $this->parseMarkdown($propVal);
@@ -494,7 +498,7 @@ class Markdown {
 			
             $siteURL = $this->urlencodeFileName($siteURL);
 			$blogId = md5($siteURL);
-			
+
 			$blog = array(
 				"blogId" => $blogId,
 				"fileName" => $fileName,
@@ -502,12 +506,12 @@ class Markdown {
 				"sitePath" => $sitePath,
 				"mtime" => $mtime,
 				"ctime" => $ctime,
-				"siteURL" => $siteURL
+				"siteURL" => $siteURL,
 			);
 			
 			//读取自定义博客属性信息
 			$blogProp = $this->readPostBaseInfo($serverPath);
-			
+
 			//没有title的博客不处理
 			if (empty($blogProp['title'])) continue;
 			
@@ -536,7 +540,6 @@ class Markdown {
 			$blog = array_merge($blog, $blogProp);
 			array_push($this->blogs, $blog);
 		}
-		
 		$this->sortBlogs($this->blogs, 'date');
 		
 		//缓存全局数据
@@ -593,14 +596,13 @@ class Markdown {
 		
 		$ctimeArr = null;
 		$dateArr = null;
-		
+		$topArr = null;
 		foreach ($blogArray as $key => $row) {
 			$dateArr[$key] = $row[$sortKey];
 			$ctimeArr[$key] = $row['mtime'];
+			$topArr[$key] = $row['top'];
 		}
-		
-		array_multisort($dateArr, SORT_DESC, $ctimeArr, SORT_DESC, $blogArray);
-		
+		array_multisort($topArr, SORT_DESC, $dateArr, SORT_DESC, $ctimeArr, SORT_DESC, $blogArray);
 		$this->blogs = $blogArray;
 	}
 	

--- a/theme/quest/blog/header.html
+++ b/theme/quest/blog/header.html
@@ -1,5 +1,5 @@
 <header class="entry-header">
-	<h1 class="post-title"><a href="{{ blog.siteURL}}" rel="bookmark">{{ blog.title}}</a></h1>
+	<h1 class="post-title"><a href="{{ blog.siteURL}}" rel="bookmark">{{ blog.title}} {% if blog.top != 0 %}<span class="top">[置顶]</span>{% endif %}</a></h1>
 	<div class="entry-meta">
 		<time class="post-date"><i class="fa fa-clock-o"></i>{{ blog.date}}</time>
 		{% if blog.author %}

--- a/theme/quest/css/style.css
+++ b/theme/quest/css/style.css
@@ -53,6 +53,9 @@ body {
 span a:hover {
   color: #27ae60; }
 
+.top {
+  color: #00A2EB;
+}
 h1 {
   font-size: 22px;
   font-weight: 300;

--- a/theme/simple/detail.html
+++ b/theme/simple/detail.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="post">
 	<header class="post-header">
-		<h1 class="post-title">{{ blog.title }}</h1>
+		<h1 class="post-title">{{ blog.title }} {% if blog.top != 0 %}<span class="top">[置顶]</span>{% endif %}</h1>
 		<p class="post-meta">{{ blog.date | date('Y-m-d') }}{% if blog.author %} • {{ blog.author }}{% endif %}{% if blog.keywords %} • {{ blog.keywords | join(',') }}{% endif %}</p>
 	</header>
 	<article class="post-content">

--- a/theme/simple/index.html
+++ b/theme/simple/index.html
@@ -9,7 +9,7 @@
 		{% if blog.title %}
 		<li>
 			<span class="post-meta">{{ blog.date | date("Y-m-d")}}</span>
-			<h2><a class="post-link" href="{{ blog.siteURL }}">{{ blog.title }}</a></h2>
+			<h2><a class="post-link" href="{{ blog.siteURL }}">{{ blog.title }} {% if blog.top != 0 %}<span class="top">[置顶]</span>{% endif %}</a></h2>
 		</li>
 		{% endif %}
 		{% endfor %}


### PR DESCRIPTION
文章中新增置顶功能。在文章配置中以top字段声明，如:

``` html
<!--
top: 1
-->
```
## 默认或为0为不置顶，非零按照top数字大小倒序排列。

主题中只修改了两个主题对于新增置顶功能的样式，分别为quest与simple
