### PR TITLE
更新 Parsedown.php V1.5.0 至 V1.6.0 以兼容 PHP7

### DIFF
--- a/app/libraries/Yaml.php
+++ b/app/libraries/Yaml.php
@@ -26,6 +26,7 @@ class Yaml {
     		"enableCache" => true,
     		"highlight" => true,
     		"mathjax" => false,
+    		"katex" => false,
     		"duoshuo" => "",
     		"baiduAnalytics" => "",
     		"keywords" => "GitBlog,博客,Markdown博客,jockchou",

--- a/app/third_party/parsedown/Parsedown.php
+++ b/app/third_party/parsedown/Parsedown.php
@@ -17,7 +17,7 @@ class Parsedown
 {
     # ~
 
-    const version = '1.5.0';
+    const version = '1.6.0';
 
     # ~
 
@@ -107,12 +107,6 @@ class Parsedown
 
     # ~
 
-    protected $DefinitionTypes = array(
-        '[' => array('Reference'),
-    );
-
-    # ~
-
     protected $unmarkedBlockTypes = array(
         'Code',
     );
@@ -121,7 +115,7 @@ class Parsedown
     # Blocks
     #
 
-    private function lines(array $lines)
+    protected function lines(array $lines)
     {
         $CurrentBlock = null;
 
@@ -169,7 +163,7 @@ class Parsedown
 
             # ~
 
-            if (isset($CurrentBlock['incomplete']))
+            if (isset($CurrentBlock['continuable']))
             {
                 $Block = $this->{'block'.$CurrentBlock['type'].'Continue'}($Line, $CurrentBlock);
 
@@ -181,12 +175,10 @@ class Parsedown
                 }
                 else
                 {
-                    if (method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+                    if ($this->isBlockCompletable($CurrentBlock['type']))
                     {
                         $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
                     }
-
-                    unset($CurrentBlock['incomplete']);
                 }
             }
 
@@ -224,9 +216,9 @@ class Parsedown
                         $Block['identified'] = true;
                     }
 
-                    if (method_exists($this, 'block'.$blockType.'Continue'))
+                    if ($this->isBlockContinuable($blockType))
                     {
-                        $Block['incomplete'] = true;
+                        $Block['continuable'] = true;
                     }
 
                     $CurrentBlock = $Block;
@@ -253,7 +245,7 @@ class Parsedown
 
         # ~
 
-        if (isset($CurrentBlock['incomplete']) and method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+        if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
         {
             $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
         }
@@ -284,6 +276,16 @@ class Parsedown
         # ~
 
         return $markup;
+    }
+
+    protected function isBlockContinuable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Continue');
+    }
+
+    protected function isBlockCompletable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Complete');
     }
 
     #
@@ -394,16 +396,16 @@ class Parsedown
 
     protected function blockFencedCode($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].']{3,})[ ]*([\w-]+)?[ ]*$/', $Line['text'], $matches))
+        if (preg_match('/^['.$Line['text'][0].']{3,}[ ]*([\w-]+)?[ ]*$/', $Line['text'], $matches))
         {
             $Element = array(
                 'name' => 'code',
                 'text' => '',
             );
 
-            if (isset($matches[2]))
+            if (isset($matches[1]))
             {
-                $class = 'language-'.$matches[2];
+                $class = 'language-'.$matches[1];
 
                 $Element['attributes'] = array(
                     'class' => $class,
@@ -488,9 +490,9 @@ class Parsedown
                     'name' => 'h' . min(6, $level),
                     'text' => $text,
                     'handler' => 'line',
-					'attributes' => array(
-						'id' => $text,
-					),
+                    'attributes' => array(
+                        'id' => $text,
+                    ),
                 ),
             );
 
@@ -515,6 +517,16 @@ class Parsedown
                     'handler' => 'elements',
                 ),
             );
+
+            if($name === 'ol') 
+            {
+                $listStart = stristr($matches[0], '.', true);
+                
+                if($listStart !== '1')
+                {
+                    $Block['element']['attributes'] = array('start' => $listStart);
+                }
+            }
 
             $Block['li'] = array(
                 'name' => 'li',
@@ -676,7 +688,9 @@ class Parsedown
 
         if (preg_match('/^<(\w*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
         {
-            if (in_array($matches[1], $this->textLevelElements))
+            $element = strtolower($matches[1]);
+
+            if (in_array($element, $this->textLevelElements))
             {
                 return;
             }
@@ -739,8 +753,6 @@ class Parsedown
             {
                 $Block['closed'] = true;
             }
-
-            $Block['markup'] .= $matches[1];
         }
 
         if (isset($Block['interrupted']))
@@ -992,15 +1004,13 @@ class Parsedown
     {
         $markup = '';
 
-        $unexaminedText = $text;
+        # $excerpt is based on the first occurrence of a marker
 
-        $markerPosition = 0;
-
-        while ($excerpt = strpbrk($unexaminedText, $this->inlineMarkerList))
+        while ($excerpt = strpbrk($text, $this->inlineMarkerList))
         {
             $marker = $excerpt[0];
 
-            $markerPosition += strpos($unexaminedText, $marker);
+            $markerPosition = strpos($text, $marker);
 
             $Excerpt = array('text' => $excerpt, 'context' => $text);
 
@@ -1013,34 +1023,42 @@ class Parsedown
                     continue;
                 }
 
-                if (isset($Inline['position']) and $Inline['position'] > $markerPosition) # position is ahead of marker
+                # makes sure that the inline belongs to "our" marker
+
+                if (isset($Inline['position']) and $Inline['position'] > $markerPosition)
                 {
                     continue;
                 }
+
+                # sets a default inline position
 
                 if ( ! isset($Inline['position']))
                 {
                     $Inline['position'] = $markerPosition;
                 }
 
+                # the text that comes before the inline
                 $unmarkedText = substr($text, 0, $Inline['position']);
 
+                # compile the unmarked text
                 $markup .= $this->unmarkedText($unmarkedText);
 
+                # compile the inline
                 $markup .= isset($Inline['markup']) ? $Inline['markup'] : $this->element($Inline['element']);
 
+                # remove the examined text
                 $text = substr($text, $Inline['position'] + $Inline['extent']);
-
-                $unexaminedText = $text;
-
-                $markerPosition = 0;
 
                 continue 2;
             }
 
-            $unexaminedText = substr($excerpt, 1);
+            # the marker does not belong to an inline
 
-            $markerPosition ++;
+            $unmarkedText = substr($text, 0, $markerPosition + 1);
+
+            $markup .= $this->unmarkedText($unmarkedText);
+
+            $text = substr($text, $markerPosition + 1);
         }
 
         $markup .= $this->unmarkedText($text);
@@ -1202,7 +1220,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^[(]((?:[^ (]|[(][^ )]+[)])+)(?:[ ]+("[^"]+"|\'[^\']+\'))?[)]/', $remainder, $matches))
+        if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:[ ]+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
         {
             $Element['attributes']['href'] = $matches[1];
 
@@ -1217,7 +1235,7 @@ class Parsedown
         {
             if (preg_match('/^\s*\[(.*?)\]/', $remainder, $matches))
             {
-                $definition = $matches[1] ? $matches[1] : $Element['text'];
+                $definition = strlen($matches[1]) ? $matches[1] : $Element['text'];
                 $definition = strtolower($definition);
 
                 $extent += strlen($matches[0]);
@@ -1363,11 +1381,6 @@ class Parsedown
         }
     }
 
-    #
-    # ~
-
-    protected $unmarkedInlineTypes = array("\n" => 'Break', '://' => 'Url');
-
     # ~
 
     protected function unmarkedText($text)
@@ -1412,7 +1425,7 @@ class Parsedown
 
             if (isset($Element['handler']))
             {
-                $markup .= $this->$Element['handler']($Element['text']);
+                $markup .= $this->{$Element['handler']}($Element['text']);
             }
             else
             {
@@ -1486,7 +1499,7 @@ class Parsedown
             return self::$instances[$name];
         }
 
-        $instance = new self();
+        $instance = new static();
 
         self::$instances[$name] = $instance;
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -7,6 +7,7 @@ theme: simple
 enableCache: true
 highlight: true
 mathjax: false
+katex: false
 duoshuo:
 baiduAnalytics:
 keywords: GitBlog,博客,Markdown博客,jockchou

--- a/theme/beach/_layouts/base.html
+++ b/theme/beach/_layouts/base.html
@@ -54,5 +54,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+	delimiters: [
+	// 段落模式 $$...$$ \[...\]
+	{left: "$$", right: "$$", display: true},
+	{left: "\\[", right: "\\]", display: true},
+	// 行内模式 $...$ \(...\)
+	{left: "$", right: "$", display: false},
+	{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>

--- a/theme/cube/_layouts/default.html
+++ b/theme/cube/_layouts/default.html
@@ -14,5 +14,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+	delimiters: [
+	// 段落模式 $$...$$ \[...\]
+	{left: "$$", right: "$$", display: true},
+	{left: "\\[", right: "\\]", display: true},
+	// 行内模式 $...$ \(...\)
+	{left: "$", right: "$", display: false},
+	{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>

--- a/theme/default/block/base.html
+++ b/theme/default/block/base.html
@@ -80,10 +80,10 @@ render_option = {
 			],
 				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
-// renderMathInElement(document.body, render_option);
-var elems_content = document.getElementsByClassName('entry-content');
-for ( var i = 0; i < elems_content.length; i++)
-	renderMathInElement(elems_content[i], render_option);
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/default/block/base.html
+++ b/theme/default/block/base.html
@@ -63,5 +63,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+		delimiters: [
+					// 段落模式 $$...$$ \[...\]
+					{left: "$$", right: "$$", display: true},
+							{left: "\\[", right: "\\]", display: true},
+									// 行内模式 $...$ \(...\)
+									{left: "$", right: "$", display: false},
+											{left: "\\(", right: "\\)", display: false}
+			],
+				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+// renderMathInElement(document.body, render_option);
+var elems_content = document.getElementsByClassName('entry-content');
+for ( var i = 0; i < elems_content.length; i++)
+	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>

--- a/theme/line/_layouts/default.html
+++ b/theme/line/_layouts/default.html
@@ -14,5 +14,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+	delimiters: [
+	// 段落模式 $$...$$ \[...\]
+	{left: "$$", right: "$$", display: true},
+	{left: "\\[", right: "\\]", display: true},
+	// 行内模式 $...$ \(...\)
+	{left: "$", right: "$", display: false},
+	{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>

--- a/theme/quest/block/base.html
+++ b/theme/quest/block/base.html
@@ -73,10 +73,10 @@ render_option = {
 			],
 				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
-// renderMathInElement(document.body, render_option);
-var elems_content = document.getElementsByClassName('entry-content');
-for ( var i = 0; i < elems_content.length; i++)
-	renderMathInElement(elems_content[i], render_option);
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/quest/block/base.html
+++ b/theme/quest/block/base.html
@@ -56,5 +56,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+		delimiters: [
+					// 段落模式 $$...$$ \[...\]
+					{left: "$$", right: "$$", display: true},
+							{left: "\\[", right: "\\]", display: true},
+									// 行内模式 $...$ \(...\)
+									{left: "$", right: "$", display: false},
+											{left: "\\(", right: "\\)", display: false}
+			],
+				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+// renderMathInElement(document.body, render_option);
+var elems_content = document.getElementsByClassName('entry-content');
+for ( var i = 0; i < elems_content.length; i++)
+	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>

--- a/theme/simple/_layouts/default.html
+++ b/theme/simple/_layouts/default.html
@@ -20,5 +20,28 @@
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
 <script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
+{% if site.katex %}
+<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<script type="text/javascript">
+render_option = {
+	delimiters: [
+	// 段落模式 $$...$$ \[...\]
+	{left: "$$", right: "$$", display: true},
+	{left: "\\[", right: "\\]", display: true},
+	// 行内模式 $...$ \(...\)
+	{left: "$", right: "$", display: false},
+	{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+}
+renderMathInElement(document.body, render_option);
+//var elems_content = document.getElementsByClassName('entry-content');
+//for ( var i = 0; i < elems_content.length; i++)
+//	renderMathInElement(elems_content[i], render_option);
+</script>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
1. 将 app/third_party/parsedown/Parsedown.php (V1.5.0) 更新至 https://github.com/erusev/parsedown (V1.6.0)，以解决 PHP7 报错：
```
ERROR --> Severity: error --> Exception: Function name must be a string  /var/www/gitblog/app/third_party/parsedown/Parsedown.php 1415
```

2. 保留 line 493-495 commit 02220ce  的修改：
> 添加h标签的id“
> ckeyer committed on Aug 30, 2015
