### PR TITLE
解决 cube 主题和 quest主题加载不了 fonts.useso.com 上字体的问题

### DIFF
--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -6,7 +6,8 @@ subtitle        : 自豪地采用GitBlog            #博客副标题
 theme           : quest                        #主题名称
 enableCache     : true                         #是否开启缓存
 highlight       : on                           #是否开启代码高亮支持
-mathjax         : on                           #是否开启数学公式支持
+mathjax         : on                           #是否开启MathJax数学公式渲染支持，MathJax和KaTeX互斥
+katex           : on                           #是否开启KaTeX数学公式渲染支持，MathJax和KaTeX互斥
 duoshuo         : jockchou                     #多说评论框ID
 baiduAnalytics  : 732acc76ff6bd41343951a67cbfafe34  #百度统计ID
 keywords        : jockchou,markdown,blog,php,github #网站关键字

--- a/theme/beach/_layouts/base.html
+++ b/theme/beach/_layouts/base.html
@@ -72,9 +72,6 @@ render_option = {
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/beach/_layouts/base.html
+++ b/theme/beach/_layouts/base.html
@@ -13,7 +13,7 @@
     <link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
     
     <!--[if IE]>
-	<script src="http://cdn.bootcss.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+	<script src="//cdn.bootcss.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 	<![endif]-->
 	
     <!--[if IE 6]>
@@ -45,29 +45,29 @@
     </section>
 
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
 	delimiters: [
-	// 段落模式 $$...$$ \[...\]
-	{left: "$$", right: "$$", display: true},
-	{left: "\\[", right: "\\]", display: true},
-	// 行内模式 $...$ \(...\)
-	{left: "$", right: "$", display: false},
-	{left: "\\(", right: "\\)", display: false}
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
 	],
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }

--- a/theme/cube/_includes/head.html
+++ b/theme/cube/_includes/head.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="/theme/cube/css/style-mobile.css?ver={{ site.version }}">
 	<link rel="stylesheet" href="/theme/cube/css/main.css?ver={{ site.version }}">
 	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
-    <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" rel="stylesheet" type="text/css">
     
 	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];

--- a/theme/cube/_includes/head.html
+++ b/theme/cube/_includes/head.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="/theme/cube/css/style-mobile.css?ver={{ site.version }}">
 	<link rel="stylesheet" href="/theme/cube/css/main.css?ver={{ site.version }}">
 	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
-    <link href="http://fonts.useso.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" rel="stylesheet" type="text/css">
+    <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" rel="stylesheet" type="text/css">
     
 	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];

--- a/theme/cube/_layouts/default.html
+++ b/theme/cube/_layouts/default.html
@@ -5,29 +5,29 @@
 {% block content %}{% endblock %}
 
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/github.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/github.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
 	delimiters: [
-	// 段落模式 $$...$$ \[...\]
-	{left: "$$", right: "$$", display: true},
-	{left: "\\[", right: "\\]", display: true},
-	// 行内模式 $...$ \(...\)
-	{left: "$", right: "$", display: false},
-	{left: "\\(", right: "\\)", display: false}
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
 	],
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }

--- a/theme/cube/_layouts/default.html
+++ b/theme/cube/_layouts/default.html
@@ -32,9 +32,6 @@ render_option = {
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/default/block/base.html
+++ b/theme/default/block/base.html
@@ -81,9 +81,6 @@ render_option = {
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/default/block/base.html
+++ b/theme/default/block/base.html
@@ -54,31 +54,31 @@
 {% include "block/script.html" %}
 
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/github.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/github.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
-		delimiters: [
-					// 段落模式 $$...$$ \[...\]
-					{left: "$$", right: "$$", display: true},
-							{left: "\\[", right: "\\]", display: true},
-									// 行内模式 $...$ \(...\)
-									{left: "$", right: "$", display: false},
-											{left: "\\(", right: "\\)", display: false}
-			],
-				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+	delimiters: [
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
 //var elems_content = document.getElementsByClassName('entry-content');

--- a/theme/line/_layouts/default.html
+++ b/theme/line/_layouts/default.html
@@ -5,29 +5,29 @@
 	{% block content %}{% endblock %}
 	
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
 	delimiters: [
-	// 段落模式 $$...$$ \[...\]
-	{left: "$$", right: "$$", display: true},
-	{left: "\\[", right: "\\]", display: true},
-	// 行内模式 $...$ \(...\)
-	{left: "$", right: "$", display: false},
-	{left: "\\(", right: "\\)", display: false}
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
 	],
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }

--- a/theme/line/_layouts/default.html
+++ b/theme/line/_layouts/default.html
@@ -32,9 +32,6 @@ render_option = {
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/quest/block/base.html
+++ b/theme/quest/block/base.html
@@ -10,7 +10,7 @@
 	
 	<link rel="stylesheet" href="/theme/quest/assets/plugins/bootstrap/css/bootstrap.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="stylesheet" href="/theme/quest/assets/plugins/font-awesome/css/font-awesome.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="http://fonts.useso.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext">
+	<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext">
 	<link rel="stylesheet" href="/theme/quest/css/style.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="stylesheet" href="/theme/quest/css/customizer.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
@@ -47,36 +47,33 @@
 <script type="text/javascript" src="/theme/quest/assets/js/quest.js?ver={{ confObj.version }}"></script>
 	
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/default.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/default.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
-		delimiters: [
-					// 段落模式 $$...$$ \[...\]
-					{left: "$$", right: "$$", display: true},
-							{left: "\\[", right: "\\]", display: true},
-									// 行内模式 $...$ \(...\)
-									{left: "$", right: "$", display: false},
-											{left: "\\(", right: "\\)", display: false}
-			],
-				ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+	delimiters: [
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
+	],
+	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>

--- a/theme/quest/block/base.html
+++ b/theme/quest/block/base.html
@@ -10,7 +10,7 @@
 	
 	<link rel="stylesheet" href="/theme/quest/assets/plugins/bootstrap/css/bootstrap.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="stylesheet" href="/theme/quest/assets/plugins/font-awesome/css/font-awesome.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext">
+	<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext">
 	<link rel="stylesheet" href="/theme/quest/css/style.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="stylesheet" href="/theme/quest/css/customizer.css?ver={{ confObj.version }}" type="text/css" media="all" />
 	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />

--- a/theme/simple/_layouts/default.html
+++ b/theme/simple/_layouts/default.html
@@ -11,29 +11,29 @@
 	{% include "_includes/footer.html" %}
 
 {% if site.highlight %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
-<script src="http://cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/magula.min.css">
+<script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
 {% if site.mathjax %}
 <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="http://cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
-<link rel="stylesheet" href="http://cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
-<script src="https://cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+<link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
+<script src="//cdn.bootcss.com/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 <script type="text/javascript">
 render_option = {
 	delimiters: [
-	// 段落模式 $$...$$ \[...\]
-	{left: "$$", right: "$$", display: true},
-	{left: "\\[", right: "\\]", display: true},
-	// 行内模式 $...$ \(...\)
-	{left: "$", right: "$", display: false},
-	{left: "\\(", right: "\\)", display: false}
+		// 段落模式 $$...$$ \[...\]
+		{left: "$$", right: "$$", display: true},
+		{left: "\\[", right: "\\]", display: true},
+		// 行内模式 $...$ \(...\)
+		{left: "$", right: "$", display: false},
+		{left: "\\(", right: "\\)", display: false}
 	],
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }

--- a/theme/simple/_layouts/default.html
+++ b/theme/simple/_layouts/default.html
@@ -38,9 +38,6 @@ render_option = {
 	ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"]
 }
 renderMathInElement(document.body, render_option);
-//var elems_content = document.getElementsByClassName('entry-content');
-//for ( var i = 0; i < elems_content.length; i++)
-//	renderMathInElement(elems_content[i], render_option);
 </script>
 {% endif %}
 </body>


### PR DESCRIPTION
主要进行了四处更改

1. `theme/quest/block/base.html:13, theme/cube/_includes/head.html:11cube` 使用了 360 的fonts.useso.com 服务；因为近期 google fonts 在大陆恢复了服务，360 紧接着停止了 fonts.useso.com 的字体服务，导致 cube 主题和 quest 主题加载不了字体，打开缓慢；所以更改了两个主题的字体资源加载位置以解决此问题。

2. https下加载http资源警告，cdn.bootcss.com和googleapis.com支持http和https，所以修改了这两家的资源加载以自适应，href="//..."，涉及 cube 和 quest 主题的字体加载 和 全部主题的 mathjax katex 加载。

3. 删除了 KaTeX 不必要的注释，更改了错误的缩进，与 MathJax 的标识符设置保持了一致，以便无缝切换两种渲染方式。

4. 增加了 example-conf.yaml 里关于 KaTeX 的设置样例。