### PR TITLE
修复多说文章列表URL混乱文题;添加disqus评论框支持;实现全文关键字搜索功能

### DIFF
--- a/app/controllers/Gitblog.php
+++ b/app/controllers/Gitblog.php
@@ -445,7 +445,7 @@ class Gitblog extends CI_Controller
 		$this->init();
 
 		if (!empty($keyword)) {
-			$blogList = $this->markdown->getBlogByTitle($keyword);
+			$blogList = $this->markdown->getBlogByKeyword($keyword);
 		}
 
 		$this->setData("pageName", "search");

--- a/app/controllers/Gitblog.php
+++ b/app/controllers/Gitblog.php
@@ -3,543 +3,546 @@
 class Gitblog extends CI_Controller
 {
 
-    //配置信息
-    private $confObj;
-
-    //渲染时的数据绑定
-    private $data;
-
-    //是否导出操作
-    private $export = false;
-
-    //配置文件
-    private $configFile;
-
-    //博客路径
-    private $blogPath;
-
-    function __construct()
-    {
-        parent::__construct();
-        $this->load->helper('file');
-        $this->load->helper('url');
-        $this->load->driver('cache');
-
-        $this->configFile = str_replace("\\", "/", dirname(APPPATH)) . '/' . GB_CONF_FILE;
-        $this->blogPath = str_replace("\\", "/", dirname(APPPATH)) . '/blog/';
-    }
-
-    //导出网站
-    public function exportSite()
-    {
-
-        //非命令行访问，返回404
-        if (!$this->input->is_cli_request()) {
-            return $this->go404();
-        }
-
-        $pageNo = 0;
-        $this->export = true;
-
-        //初始化
-        $this->init();
-
-        echo "\nexport index page\n";
-
-        //首页所有页面
-        $pageSize = $this->confObj['blog']['pageSize'];
-        $pages = $this->markdown->getTotalPages($pageSize);
-        for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
-            $fileContent = $this->page($pageNo);
-            $filePath = GB_SITE_DIR . "/page/";
-            if (!file_exists($filePath)) {
-                mkdir($filePath, 0755, true);
-            }
-            write_file($filePath . $pageNo . ".html", $fileContent);
-
-            if ($pageNo == 1) {
-                if (!file_exists($filePath)) {
-                    mkdir($filePath, 0755, true);
-                }
-                write_file(GB_SITE_DIR . "/index.html", $fileContent);
-            }
-        }
-        echo "export index page success\n";
-
-        echo "\nexport category page\n";
-        //分类下所有页面
-        $categoryList = $this->markdown->getAllCategorys();
-        foreach ($categoryList as $idx => $category) {
-            $categoryId = $category['id'];
-            $pages = $this->markdown->getCategoryTotalPages($categoryId, $pageSize);
-
-            for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
-                $fileContent = $this->category($categoryId, $pageNo);
-                $filePath = GB_SITE_DIR . "/category/$categoryId/page/";
-                if (!file_exists($filePath)) {
-                    mkdir($filePath, 0755, true);
-                }
-                write_file($filePath . $pageNo . ".html", $fileContent);
-                if ($pageNo == 1) {
-                    $filePath = GB_SITE_DIR . "/category/$categoryId";
-                    if (!file_exists($filePath)) {
-                        mkdir($filePath, 0755, true);
-                    }
-                    write_file($filePath . ".html", $fileContent);
-                }
-            }
-        }
-        echo "export category page success\n";
-
-        echo "\nexport tag page\n";
-        //标签下所有页面
-        $tagsList = $this->markdown->getAllTags();
-        foreach ($tagsList as $idx => $tag) {
-            $tagId = $tag['id'];
-            $pages = $this->markdown->getTagTotalPages($tagId, $pageSize);
-
-            for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
-                $fileContent = $this->tags($tagId, $pageNo);
-                $filePath = GB_SITE_DIR . "/tags/$tagId/page/";
-                if (!file_exists($filePath)) {
-                    mkdir($filePath, 0755, true);
-                }
-                write_file($filePath . $pageNo . ".html", $fileContent);
-                if ($pageNo == 1) {
-                    $filePath = GB_SITE_DIR . "/tags/$tagId";
-                    if (!file_exists($filePath)) {
-                        mkdir($filePath, 0755, true);
-                    }
-                    write_file($filePath . ".html", $fileContent);
-                }
-            }
-        }
-        echo "export tag page success\n";
-
-        echo "\nexport archive page\n";
-        //归档下所有页面
-        $yearMonthList = $this->markdown->getAllYearMonths();
-        foreach ($yearMonthList as $idx => $yearMonth) {
-            $yearMonthId = $yearMonth['id'];
-            $pages = $this->markdown->getYearMonthTotalPages($yearMonthId, $pageSize);
-
-            for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
-                $fileContent = $this->archive($yearMonthId, $pageNo);
-                $filePath = GB_SITE_DIR . "/archive/$yearMonthId/page/";
-                if (!file_exists($filePath)) {
-                    mkdir($filePath, 0755, true);
-                }
-                write_file($filePath . $pageNo . ".html", $fileContent);
-                if ($pageNo == 1) {
-                    $filePath = GB_SITE_DIR . "/archive/$yearMonthId";
-                    if (!file_exists($filePath)) {
-                        mkdir($filePath, 0755, true);
-                    }
-                    write_file($filePath . ".html", $fileContent);
-                }
-            }
-        }
-        echo "\nexport archive page success\n";
-
-        echo "\nexport detail page\n";
-        //博客详情页
-        $blogList = $this->markdown->getAllBlogs();
-        foreach ($blogList as $idx => $blog) {
-            $blogId = $blog['blogId'];
-            $siteURL = '/' . str_replace(trim(base_url("", ""),":"), "", $blog['siteURL']);
-            $fileName = $blog['fileName'];
-            $fileName = $this->markdown->changeFileExt($fileName);
-            $filePath = str_replace($fileName, "", $siteURL);
-            $filePath = GB_SITE_DIR . $filePath;
-            if (!file_exists($filePath)) {
-                mkdir($filePath, 0755, true);
-            }
-
-            $fileContent = $this->blog($blogId);
-            write_file(GB_SITE_DIR . $siteURL, $fileContent);
-        }
-        echo "export detail page success\n";
-
-        echo "\ncopy theme\n";
-        //复制主题到目录下
-        $theme = $this->confObj['theme'];
-        $thfiles = get_dir_file_info("./theme/" . $theme, false);
-        foreach ($thfiles as $fileName => $file) {
-            $pics = explode('.', $fileName);
-            $fileExt = strtolower(end($pics));
-
-            if ($fileExt != "html") {
-                $serverPath = $file['server_path'];
-                $serverPath = str_replace("\\", "/", $serverPath);
-
-                $targetFile = GB_SITE_DIR . substr($serverPath, strpos($serverPath, "/theme/" . $theme));
-                $targetPath = str_replace(basename($fileName), "", $targetFile);
-
-                if (!file_exists($targetPath)) {
-                    mkdir($targetPath, 0755, true);
-                }
-
-                copy($serverPath, $targetFile);
-            }
-        }
-        echo "copy theme success\n";
-
-        echo "\ncopy image\n";
-        //复制图片文件夹
-        $thfiles = get_dir_file_info("./blog/img/", false);
-        foreach ($thfiles as $fileName => $file) {
-            $serverPath = $file['server_path'];
-            $serverPath = str_replace("\\", "/", $serverPath);
-
-            $targetPath = GB_SITE_DIR . "/blog/img/";
-            $targetFile = GB_SITE_DIR . "/blog/img/" . $file['name'];
-            if (!file_exists($targetPath)) {
-                mkdir($targetPath, 0755, true);
-            }
-            copy($serverPath, $targetFile);
-        }
-        echo "copy image success\n";
-
-        echo "\ncopy feed.xml, robots.txt, favicon.ico\n";
-        //feed.xml文件
-        $feedXmlfilePath = GB_SITE_DIR . "/feed.xml";
-        $feedXmlfileContent = $this->feed();
-        write_file($feedXmlfilePath, $feedXmlfileContent);
-
-        copy("robots.txt", GB_SITE_DIR . "/robots.txt");
-        copy("favicon.ico", GB_SITE_DIR . "/favicon.ico");
-
-        echo "\nexport site success!!!\n";
-    }
-
-    //首页
-    public function index()
-    {
-        $this->page(1);
-    }
-
-    private function init()
-    {
-        //加载必要的类库
-        $this->load->library('Yaml');
-        $this->load->library('Markdown');
-        $this->load->library('Pager');
-
-        //加载配置文件
-        $this->confObj = $this->yaml->getConfObject($this->configFile);
-
-        //侧边栏最近博客条数
-        $recentSize = $this->confObj['blog']['recentSize'];
-
-        //是否需要所有博客
-        $allBlogsForPage = $this->confObj['blog']['allBlogsForPage'];
-
-        //加载模板引擎
-        $this->load->library('Twig', array("theme" => $this->confObj['theme']));
-
-        //初始化博客信息
-        $this->markdown->initAllBlogData($this->blogPath, $this->confObj['enableCache']);
-
-        //所有博客
-        $allBlogsList = null;
-        if ($allBlogsForPage) {
-            //所有博客
-            $allBlogsList = $this->markdown->getAllBlogs();
-        }
-
-        //所有分类
-        $categoryList = $this->markdown->getAllCategorys();
-
-        //所有标签
-        $tagsList = $this->markdown->getAllTags();
-
-        //归档月份
-        $yearMonthList = $this->markdown->getAllYearMonths();
-
-        //最近博客
-        $recentBlogList = $this->markdown->getBlogsRecent($recentSize);
-
-        //设置数据
-        $this->setData("allBlogsList", $allBlogsList);
-        $this->setData("categoryList", $categoryList);
-        $this->setData("tagsList", $tagsList);
-        $this->setData("yearMonthList", $yearMonthList);
-        $this->setData("recentBlogList", $recentBlogList);
-        $this->setData("confObj", $this->confObj);
-
-        //配置名件对象别名
-        $this->setData("site", $this->confObj);
-    }
-
-    //加载缓存文件
-    private function loadOutCache()
-    {
-        $fag = false;
-        $cacheKey = $this->getCacheKey();
-        $html = $this->cache->file->get($this->getCacheKey());
-        if (!$html) { //没有缓存
-            $this->init();
-        } else {
-            $this->output->set_output($html);
-            $cacheHeaderVal = strtoupper(substr($cacheKey, 0, 32));
-            $this->output->set_header("Cache-Key: " . $cacheHeaderVal);
-            $fag = true;
-        }
-
-        return $fag;
-    }
-
-    //分类下的博客列表
-    public function category($categoryId, $pageNo = 1)
-    {
-        if ($this->loadOutCache()) {
-            return;
-        }
-
-        $categoryId = (int)$categoryId;
-        $pageNo = (int)$pageNo;
-        $pageSize = $this->confObj['blog']['pageSize'];
-        $pageBarSize = $this->confObj['blog']['pageBarSize'];
-
-        $pages = $this->markdown->getCategoryTotalPages($categoryId, $pageSize);
-
-        if ($pageNo <= 0) {
-            $pageNo = 1;
-        }
-
-        if ($pageNo > $pages) {
-            $pageNo = $pages;
-        }
-
-        $category = $this->markdown->getCategoryById($categoryId);
-        $pageData = $this->markdown->getBlogsPageByCategory($categoryId, $pageNo, $pageSize);
-        $pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "category/$categoryId/");
-
-        $this->setData("pagination", $pagination);
-        $this->setData("pageName", "category");
-        $this->setData("categoryId", $categoryId);
-        $this->setData("category", $category);
-        $this->setData("pageNo", $pageNo);
-        $this->setData("pages", $pageData['pages']);
-        $this->setData("blogList", $pageData['blogList']);
-
-        return $this->render('index.html');
-    }
-
-    //按月归档下的博客列表
-    public function archive($yearMonthId, $pageNo = 1)
-    {
-        if ($this->loadOutCache()) {
-            return;
-        }
-
-        $pageNo = (int)$pageNo;
-        $pageSize = $this->confObj['blog']['pageSize'];
-        $pageBarSize = $this->confObj['blog']['pageBarSize'];
-
-        $pages = $this->markdown->getYearMonthTotalPages($yearMonthId, $pageSize);
-
-        if ($pageNo <= 0) {
-            $pageNo = 1;
-        }
-
-        if ($pageNo > $pages) {
-            $pageNo = $pages;
-        }
-
-        $yearMonth = $this->markdown->getYearMonthById($yearMonthId);
-        $pageData = $this->markdown->getBlogsPageByYearMonth($yearMonthId, $pageNo, $pageSize);
-        $pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "archive/$yearMonthId/");
-
-        $this->setData("pagination", $pagination);
-        $this->setData("pageName", "archive");
-        $this->setData("yearMonthId", $yearMonthId);
-        $this->setData("yearMonth", $yearMonth);
-        $this->setData("pageNo", $pageNo);
-        $this->setData("pages", $pageData['pages']);
-        $this->setData("blogList", $pageData['blogList']);
-
-        return $this->render('index.html');
-    }
-
-    //标签下的博客列表
-    public function tags($tagId, $pageNo = 1)
-    {
-        if ($this->loadOutCache()) {
-            return;
-        }
-
-        $this->pageName = "tags";
-
-        $tagId = (int)$tagId;
-        $pageNo = (int)$pageNo;
-        $pageSize = $this->confObj['blog']['pageSize'];
-        $pageBarSize = $this->confObj['blog']['pageBarSize'];
-
-        $pages = $this->markdown->getTagTotalPages($tagId, $pageSize);
-
-        if ($pageNo <= 0) {
-            $pageNo = 1;
-        }
-
-        if ($pageNo > $pages) {
-            $pageNo = $pages;
-        }
-
-        $tag = $this->markdown->getTagById($tagId);
-        $pageData = $this->markdown->getBlogsPageByTag($tagId, $pageNo, $pageSize);
-        $pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "/tags/$tagId/");
-
-        $this->setData("pagination", $pagination);
-        $this->setData("pageName", "tags");
-        $this->setData("tagId", $tagId);
-        $this->setData("tag", $tag);
-        $this->setData("pageNo", $pageNo);
-        $this->setData("pages", $pageData['pages']);
-        $this->setData("blogList", $pageData['blogList']);
-
-        return $this->render('index.html');
-    }
-
-    //首页，博客列表
-    public function page($pageNo = 1)
-    {
-        if ($this->loadOutCache()) {
-            return;
-        }
-
-        $pageNo = (int)$pageNo;
-        $pageSize = $this->confObj['blog']['pageSize'];
-        $pageBarSize = $this->confObj['blog']['pageBarSize'];
-
-        $pages = $this->markdown->getTotalPages($pageSize);
-        if ($pageNo <= 0) {
-            $pageNo = 1;
-        }
-
-        if ($pageNo > $pages) {
-            $pageNo = $pages;
-        }
-        $pageData = $this->markdown->getBlogsByPage($pageNo, $pageSize);
-
-        $pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize);
-        $this->setData("pagination", $pagination);
-
-        $this->setData("pageName", "home");
-        $this->setData("pageNo", $pageNo);
-        $this->setData("pages", $pageData['pages']);
-        $this->setData("blogList", $pageData['blogList']);
-
-        return $this->render('index.html');
-    }
-
-    public function search()
-    {
-        $keyword = $this->input->get_post("keyword", true);
-        $keyword = trim($keyword);
-        $blogList = array();
-
-        $this->init();
-
-        if (!empty($keyword)) {
-            $blogList = $this->markdown->getBlogByTitle($keyword);
-        }
-
-        $this->setData("pageName", "search");
-        $this->setData("keyword", $keyword);
-        $this->setData("blogList", $blogList);
-
-        return $this->render('index.html');
-    }
-
-    //博客详情页
-    public function blog($blogId = null)
-    {
-        if ($this->loadOutCache()) {
-            return;
-        }
-
-        if (!$blogId) {
-            $blogId = md5(uri_string());
-        }
-
-        $blog = $this->markdown->getBlogById($blogId);
-
-        if ($blog == null) {
-            return $this->go404();
-        }
-
-        $this->setData("pageName", "blog");
-        $this->setData("blog", $blog);
-
-        return $this->render('detail.html');
-    }
-
-    //feed.xml
-    public function feed()
-    {
-
-        //加载必要的类库
-        $this->load->library('Markdown');
-        $this->load->library('Yaml');
-
-        //初始化博客信息
-        $this->markdown->initAllBlogData($this->blogPath, true);
-
-        $blogList = $this->markdown->getAllBlogs();
-
-        $data['blogList'] = $blogList;
-        $data['site'] = $this->yaml->getConfObject($this->configFile);
-
-        $feedXml = $this->load->view('feed', $data, true);
-        if (!$this->export) {
-            $this->cache->file->save('feed.xml', $feedXml, 24 * 60 * 60);
-            $this->output->set_content_type("application/xml");
-            $this->output->set_output($feedXml);
-        }
-
-        return $feedXml;
-    }
-
-    public function go404()
-    {
-        $this->init();
-
-        try {
-            set_status_header(404);
-            $this->render("404.html");
-        } catch (Twig_Error_Loader $e) {
-            show_404();
-        }
-    }
-
-    //设置渲染数据
-    private function setData($key, $dataObj)
-    {
-        $this->data[$key] = $dataObj;
-    }
-
-    //渲染页面
-    private function render($tpl)
-    {
-        $htmlPage = $this->twig->render($tpl, $this->data, true);
-
-        if (!$this->export) {
-            //生产模式下才会缓存
-            if (ENVIRONMENT == "production" && $this->confObj['enableCache']) {
-                $cacheKey = $this->getCacheKey();
-                $this->cache->file->save($cacheKey, $htmlPage, GB_PAGE_CACHE_TIME);
-            }
-
-            $this->output->set_output($htmlPage);
-        }
-
-        return $htmlPage;
-    }
-
-    //计算缓存Key
-    private function getCacheKey()
-    {
-        return $this->confObj['theme'] . "_" . md5(uri_string()) . ".html"; //category/1460001917
-    }
+	//配置信息
+	private $confObj;
+
+	//渲染时的数据绑定
+	private $data;
+
+	//是否导出操作
+	private $export = false;
+
+	//配置文件
+	private $configFile;
+
+	//博客路径
+	private $blogPath;
+
+	function __construct()
+	{
+		parent::__construct();
+		$this->load->helper('file');
+		$this->load->helper('url');
+		$this->load->driver('cache');
+
+		$this->configFile = str_replace("\\", "/", dirname(APPPATH)) . '/' . GB_CONF_FILE;
+		$this->blogPath = str_replace("\\", "/", dirname(APPPATH)) . '/blog/';
+	}
+
+	//导出网站
+	public function exportSite()
+	{
+
+		//非命令行访问，返回404
+		if (!$this->input->is_cli_request()) {
+			return $this->go404();
+		}
+
+		$pageNo = 0;
+		$this->export = true;
+
+		//初始化
+		$this->init();
+
+		echo "\nexport index page\n";
+
+		//首页所有页面
+		$pageSize = $this->confObj['blog']['pageSize'];
+		$pages = $this->markdown->getTotalPages($pageSize);
+		for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
+			$fileContent = $this->page($pageNo);
+			$filePath = GB_SITE_DIR . "/page/";
+			if (!file_exists($filePath)) {
+				mkdir($filePath, 0755, true);
+			}
+			write_file($filePath . $pageNo . ".html", $fileContent);
+
+			if ($pageNo == 1) {
+				if (!file_exists($filePath)) {
+					mkdir($filePath, 0755, true);
+				}
+				write_file(GB_SITE_DIR . "/index.html", $fileContent);
+			}
+		}
+		echo "export index page success\n";
+
+		echo "\nexport category page\n";
+		//分类下所有页面
+		$categoryList = $this->markdown->getAllCategorys();
+		foreach ($categoryList as $idx => $category) {
+			$categoryId = $category['id'];
+			$pages = $this->markdown->getCategoryTotalPages($categoryId, $pageSize);
+
+			for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
+				$fileContent = $this->category($categoryId, $pageNo);
+				$filePath = GB_SITE_DIR . "/category/$categoryId/page/";
+				if (!file_exists($filePath)) {
+					mkdir($filePath, 0755, true);
+				}
+				write_file($filePath . $pageNo . ".html", $fileContent);
+				if ($pageNo == 1) {
+					$filePath = GB_SITE_DIR . "/category/$categoryId";
+					if (!file_exists($filePath)) {
+						mkdir($filePath, 0755, true);
+					}
+					write_file($filePath . ".html", $fileContent);
+				}
+			}
+		}
+		echo "export category page success\n";
+
+		echo "\nexport tag page\n";
+		//标签下所有页面
+		$tagsList = $this->markdown->getAllTags();
+		foreach ($tagsList as $idx => $tag) {
+			$tagId = $tag['id'];
+			$pages = $this->markdown->getTagTotalPages($tagId, $pageSize);
+
+			for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
+				$fileContent = $this->tags($tagId, $pageNo);
+				$filePath = GB_SITE_DIR . "/tags/$tagId/page/";
+				if (!file_exists($filePath)) {
+					mkdir($filePath, 0755, true);
+				}
+				write_file($filePath . $pageNo . ".html", $fileContent);
+				if ($pageNo == 1) {
+					$filePath = GB_SITE_DIR . "/tags/$tagId";
+					if (!file_exists($filePath)) {
+						mkdir($filePath, 0755, true);
+					}
+					write_file($filePath . ".html", $fileContent);
+				}
+			}
+		}
+		echo "export tag page success\n";
+
+		echo "\nexport archive page\n";
+		//归档下所有页面
+		$yearMonthList = $this->markdown->getAllYearMonths();
+		foreach ($yearMonthList as $idx => $yearMonth) {
+			$yearMonthId = $yearMonth['id'];
+			$pages = $this->markdown->getYearMonthTotalPages($yearMonthId, $pageSize);
+
+			for ($pageNo = 1; $pageNo <= $pages; $pageNo++) {
+				$fileContent = $this->archive($yearMonthId, $pageNo);
+				$filePath = GB_SITE_DIR . "/archive/$yearMonthId/page/";
+				if (!file_exists($filePath)) {
+					mkdir($filePath, 0755, true);
+				}
+				write_file($filePath . $pageNo . ".html", $fileContent);
+				if ($pageNo == 1) {
+					$filePath = GB_SITE_DIR . "/archive/$yearMonthId";
+					if (!file_exists($filePath)) {
+						mkdir($filePath, 0755, true);
+					}
+					write_file($filePath . ".html", $fileContent);
+				}
+			}
+		}
+		echo "\nexport archive page success\n";
+
+		echo "\nexport detail page\n";
+		//博客详情页
+		$blogList = $this->markdown->getAllBlogs();
+		foreach ($blogList as $idx => $blog) {
+			$blogId = $blog['blogId'];
+			$siteURL = substr($blog['siteURL'], strlen($this->confObj['url']));
+			$fileName = $blog['fileName'];
+			$fileName = $this->markdown->changeFileExt($fileName);
+			$filePath = str_replace($fileName, "", $siteURL);
+			$filePath = GB_SITE_DIR . $filePath;
+			if (!file_exists($filePath)) {
+				mkdir($filePath, 0755, true);
+			}
+
+			$fileContent = $this->blog($blogId);
+			write_file(GB_SITE_DIR . $siteURL, $fileContent);
+		}
+		echo "export detail page success\n";
+
+		echo "\ncopy theme\n";
+		//复制主题到目录下
+		$theme = $this->confObj['theme'];
+		$thfiles = get_dir_file_info("./theme/" . $theme, false);
+		foreach ($thfiles as $fileName => $file) {
+			$pics = explode('.', $fileName);
+			$fileExt = strtolower(end($pics));
+
+			if ($fileExt != "html") {
+				$serverPath = $file['server_path'];
+				$serverPath = str_replace("\\", "/", $serverPath);
+
+				$targetFile = GB_SITE_DIR . substr($serverPath, strpos($serverPath, "/theme/" . $theme));
+				$targetPath = str_replace(basename($fileName), "", $targetFile);
+
+				if (!file_exists($targetPath)) {
+					mkdir($targetPath, 0755, true);
+				}
+
+				copy($serverPath, $targetFile);
+			}
+		}
+		echo "copy theme success\n";
+
+		echo "\ncopy image\n";
+		//复制图片文件夹
+		$thfiles = get_dir_file_info("./blog/img/", false);
+		foreach ($thfiles as $fileName => $file) {
+			$serverPath = $file['server_path'];
+			$serverPath = str_replace("\\", "/", $serverPath);
+
+			$targetPath = GB_SITE_DIR . "/blog/img/";
+			$targetFile = GB_SITE_DIR . "/blog/img/" . $file['name'];
+			if (!file_exists($targetPath)) {
+				mkdir($targetPath, 0755, true);
+			}
+			copy($serverPath, $targetFile);
+		}
+		echo "copy image success\n";
+
+		echo "\ncopy feed.xml, robots.txt, favicon.ico\n";
+		//feed.xml文件
+		$feedXmlfilePath = GB_SITE_DIR . "/feed.xml";
+		$feedXmlfileContent = $this->feed();
+		write_file($feedXmlfilePath, $feedXmlfileContent);
+
+		copy("robots.txt", GB_SITE_DIR . "/robots.txt");
+		copy("favicon.ico", GB_SITE_DIR . "/favicon.ico");
+
+		echo "\nexport site success!!!\n";
+	}
+
+	//首页
+	public function index()
+	{
+		$this->page(1);
+	}
+
+	private function init()
+	{
+		//加载必要的类库
+		$this->load->library('Yaml');
+		$this->load->library('Markdown');
+		$this->load->library('Pager');
+
+		//加载配置文件
+		$this->confObj = $this->yaml->getConfObject($this->configFile);
+
+		//自动检测url配置
+		$this->confObj['url'] = preg_replace('/^(http|https):\/\/[^\/]*?(\/.*)$/', '\\2', base_url(""));
+
+		//侧边栏最近博客条数
+		$recentSize = $this->confObj['blog']['recentSize'];
+
+		//是否需要所有博客
+		$allBlogsForPage = $this->confObj['blog']['allBlogsForPage'];
+
+		//加载模板引擎
+		$this->load->library('Twig', array("theme" => $this->confObj['theme']));
+
+		//初始化博客信息
+		$this->markdown->initAllBlogData($this->blogPath, $this->confObj['enableCache']);
+
+		//所有博客
+		$allBlogsList = null;
+		if ($allBlogsForPage) {
+			//所有博客
+			$allBlogsList = $this->markdown->getAllBlogs();
+		}
+
+		//所有分类
+		$categoryList = $this->markdown->getAllCategorys();
+
+		//所有标签
+		$tagsList = $this->markdown->getAllTags();
+
+		//归档月份
+		$yearMonthList = $this->markdown->getAllYearMonths();
+
+		//最近博客
+		$recentBlogList = $this->markdown->getBlogsRecent($recentSize);
+
+		//设置数据
+		$this->setData("allBlogsList", $allBlogsList);
+		$this->setData("categoryList", $categoryList);
+		$this->setData("tagsList", $tagsList);
+		$this->setData("yearMonthList", $yearMonthList);
+		$this->setData("recentBlogList", $recentBlogList);
+		$this->setData("confObj", $this->confObj);
+
+		//配置名件对象别名
+		$this->setData("site", $this->confObj);
+	}
+
+	//加载缓存文件
+	private function loadOutCache()
+	{
+		$fag = false;
+		$cacheKey = $this->getCacheKey();
+		$html = $this->cache->file->get($this->getCacheKey());
+		if (!$html) { //没有缓存
+			$this->init();
+		} else {
+			$this->output->set_output($html);
+			$cacheHeaderVal = strtoupper(substr($cacheKey, 0, 32));
+			$this->output->set_header("Cache-Key: " . $cacheHeaderVal);
+			$fag = true;
+		}
+
+		return $fag;
+	}
+
+	//分类下的博客列表
+	public function category($categoryId, $pageNo = 1)
+	{
+		if ($this->loadOutCache()) {
+			return;
+		}
+
+		$categoryId = (int)$categoryId;
+		$pageNo = (int)$pageNo;
+		$pageSize = $this->confObj['blog']['pageSize'];
+		$pageBarSize = $this->confObj['blog']['pageBarSize'];
+
+		$pages = $this->markdown->getCategoryTotalPages($categoryId, $pageSize);
+
+		if ($pageNo <= 0) {
+			$pageNo = 1;
+		}
+
+		if ($pageNo > $pages) {
+			$pageNo = $pages;
+		}
+
+		$category = $this->markdown->getCategoryById($categoryId);
+		$pageData = $this->markdown->getBlogsPageByCategory($categoryId, $pageNo, $pageSize);
+		$pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "category/$categoryId/");
+
+		$this->setData("pagination", $pagination);
+		$this->setData("pageName", "category");
+		$this->setData("categoryId", $categoryId);
+		$this->setData("category", $category);
+		$this->setData("pageNo", $pageNo);
+		$this->setData("pages", $pageData['pages']);
+		$this->setData("blogList", $pageData['blogList']);
+
+		return $this->render('index.html');
+	}
+
+	//按月归档下的博客列表
+	public function archive($yearMonthId, $pageNo = 1)
+	{
+		if ($this->loadOutCache()) {
+			return;
+		}
+
+		$pageNo = (int)$pageNo;
+		$pageSize = $this->confObj['blog']['pageSize'];
+		$pageBarSize = $this->confObj['blog']['pageBarSize'];
+
+		$pages = $this->markdown->getYearMonthTotalPages($yearMonthId, $pageSize);
+
+		if ($pageNo <= 0) {
+			$pageNo = 1;
+		}
+
+		if ($pageNo > $pages) {
+			$pageNo = $pages;
+		}
+
+		$yearMonth = $this->markdown->getYearMonthById($yearMonthId);
+		$pageData = $this->markdown->getBlogsPageByYearMonth($yearMonthId, $pageNo, $pageSize);
+		$pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "archive/$yearMonthId/");
+
+		$this->setData("pagination", $pagination);
+		$this->setData("pageName", "archive");
+		$this->setData("yearMonthId", $yearMonthId);
+		$this->setData("yearMonth", $yearMonth);
+		$this->setData("pageNo", $pageNo);
+		$this->setData("pages", $pageData['pages']);
+		$this->setData("blogList", $pageData['blogList']);
+
+		return $this->render('index.html');
+	}
+
+	//标签下的博客列表
+	public function tags($tagId, $pageNo = 1)
+	{
+		if ($this->loadOutCache()) {
+			return;
+		}
+
+		$this->pageName = "tags";
+
+		$tagId = (int)$tagId;
+		$pageNo = (int)$pageNo;
+		$pageSize = $this->confObj['blog']['pageSize'];
+		$pageBarSize = $this->confObj['blog']['pageBarSize'];
+
+		$pages = $this->markdown->getTagTotalPages($tagId, $pageSize);
+
+		if ($pageNo <= 0) {
+			$pageNo = 1;
+		}
+
+		if ($pageNo > $pages) {
+			$pageNo = $pages;
+		}
+
+		$tag = $this->markdown->getTagById($tagId);
+		$pageData = $this->markdown->getBlogsPageByTag($tagId, $pageNo, $pageSize);
+		$pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize, "/tags/$tagId/");
+
+		$this->setData("pagination", $pagination);
+		$this->setData("pageName", "tags");
+		$this->setData("tagId", $tagId);
+		$this->setData("tag", $tag);
+		$this->setData("pageNo", $pageNo);
+		$this->setData("pages", $pageData['pages']);
+		$this->setData("blogList", $pageData['blogList']);
+
+		return $this->render('index.html');
+	}
+
+	//首页，博客列表
+	public function page($pageNo = 1)
+	{
+		if ($this->loadOutCache()) {
+			return;
+		}
+
+		$pageNo = (int)$pageNo;
+		$pageSize = $this->confObj['blog']['pageSize'];
+		$pageBarSize = $this->confObj['blog']['pageBarSize'];
+
+		$pages = $this->markdown->getTotalPages($pageSize);
+		if ($pageNo <= 0) {
+			$pageNo = 1;
+		}
+
+		if ($pageNo > $pages) {
+			$pageNo = $pages;
+		}
+		$pageData = $this->markdown->getBlogsByPage($pageNo, $pageSize);
+
+		$pagination = $this->pager->splitPage($pages, $pageNo, $pageBarSize);
+		$this->setData("pagination", $pagination);
+
+		$this->setData("pageName", "home");
+		$this->setData("pageNo", $pageNo);
+		$this->setData("pages", $pageData['pages']);
+		$this->setData("blogList", $pageData['blogList']);
+
+		return $this->render('index.html');
+	}
+
+	public function search()
+	{
+		$keyword = $this->input->get_post("keyword", true);
+		$keyword = trim($keyword);
+		$blogList = array();
+
+		$this->init();
+
+		if (!empty($keyword)) {
+			$blogList = $this->markdown->getBlogByTitle($keyword);
+		}
+
+		$this->setData("pageName", "search");
+		$this->setData("keyword", $keyword);
+		$this->setData("blogList", $blogList);
+
+		return $this->render('index.html');
+	}
+
+	//博客详情页
+	public function blog($blogId = null)
+	{
+		if ($this->loadOutCache()) {
+			return;
+		}
+
+		if (!$blogId) {
+			$blogId = md5(uri_string());
+		}
+
+		$blog = $this->markdown->getBlogById($blogId);
+
+		if ($blog == null) {
+			return $this->go404();
+		}
+
+		$this->setData("pageName", "blog");
+		$this->setData("blog", $blog);
+
+		return $this->render('detail.html');
+	}
+
+	//feed.xml
+	public function feed()
+	{
+
+		//加载必要的类库
+		$this->load->library('Markdown');
+		$this->load->library('Yaml');
+
+		//初始化博客信息
+		$this->markdown->initAllBlogData($this->blogPath, true);
+
+		$blogList = $this->markdown->getAllBlogs();
+
+		$data['blogList'] = $blogList;
+		$data['site'] = $this->yaml->getConfObject($this->configFile);
+
+		$feedXml = $this->load->view('feed', $data, true);
+		if (!$this->export) {
+			$this->cache->file->save('feed.xml', $feedXml, 24 * 60 * 60);
+			$this->output->set_content_type("application/xml");
+			$this->output->set_output($feedXml);
+		}
+
+		return $feedXml;
+	}
+
+	public function go404()
+	{
+		$this->init();
+
+		try {
+			set_status_header(404);
+			$this->render("404.html");
+		} catch (Twig_Error_Loader $e) {
+			show_404();
+		}
+	}
+
+	//设置渲染数据
+	private function setData($key, $dataObj)
+	{
+		$this->data[$key] = $dataObj;
+	}
+
+	//渲染页面
+	private function render($tpl)
+	{
+		$htmlPage = $this->twig->render($tpl, $this->data, true);
+
+		if (!$this->export) {
+			//生产模式下才会缓存
+			if (ENVIRONMENT == "production" && $this->confObj['enableCache']) {
+				$cacheKey = $this->getCacheKey();
+				$this->cache->file->save($cacheKey, $htmlPage, GB_PAGE_CACHE_TIME);
+			}
+
+			$this->output->set_output($htmlPage);
+		}
+
+		return $htmlPage;
+	}
+
+	//计算缓存Key
+	private function getCacheKey()
+	{
+		return $this->confObj['theme'] . "_" . md5(uri_string()) . ".html"; //category/1460001917
+	}
 }

--- a/app/libraries/Markdown.php
+++ b/app/libraries/Markdown.php
@@ -103,8 +103,45 @@ class Markdown {
 		return $blogList;
 	}
 
+	//按全文关键字查找博客
+	public function getBlogByKeyword($keyword, $max = 50) {
+		$keyword = strtolower($keyword);
+		$cacheKey = "getBlogByKeyword_" . (md5($keyword)) . "_" . $max . ".gb";
+		$blogList = $this->gbReadCache($cacheKey);
+
+		if ($blogList === false) {
+			$blogList = array();
+			foreach ($this->blogs as $idx => $blog) {
+				$blogTitle = strtolower($blog['title']);
+				$blogContent = strtolower(strip_tags($blog['content']));
+				$blogKeywords = strtolower($blog['keywords']);
+				$blogSummary = strtolower($blog['summary']);
+				$blogTags = '';
+				foreach ($blog['tags'] as $tag) $blogTags = $blogTags . ' ' . $tag['name'];
+				$blogCategory = '';
+				foreach ($blog['category'] as $category) $blogCategory = $blogCategory . ' ' . $category['name'];
+
+				if (
+					(strpos($blogTitle, $keyword) !== FALSE) ||
+					(strpos($blogContent, $keyword) !== FALSE) ||
+					(strpos($blogKeywords, $keyword) !== FALSE) ||
+					(strpos($blogTags, $keyword) !== FALSE) ||
+					(strpos($blogCategory, $keyword) !== FALSE) ||
+					(strpos($blogSummary, $keyword) !== FALSE) )
+				{
+					array_push($blogList, $blog);
+				}
+
+				if (count($blogList) >= $max) break;
+			}
+			$this->gbWriteCache($cacheKey, $blogList);
+		}
+		return $blogList;
+	}
+
 	//按标题关键字查找博客
 	public function getBlogByTitle($title, $max = 50) {
+		$title = strtolower($title);
 		$cacheKey = "getBlogByTitle_" . (md5($title)) . "_" . $max . ".gb";
 		$blogList = $this->gbReadCache($cacheKey);
 
@@ -112,7 +149,6 @@ class Markdown {
 			$blogList = array();
 			foreach ($this->blogs as $idx => $blog) {
 				$blogTitle = strtolower($blog['title']);
-				$title = strtolower($title);
 
 				if (strpos($blogTitle, $title) !== FALSE) {
 					array_push($blogList, $blog);

--- a/app/libraries/Markdown.php
+++ b/app/libraries/Markdown.php
@@ -20,6 +20,9 @@ class Markdown {
 	//是否开启缓存
 	private $enableCache = false;
 
+	//域名根目录下的相对网址
+	private $baseurl = "/";
+
 	//CI
 	private $CI;
 
@@ -313,8 +316,8 @@ class Markdown {
 		$this->tags = array();
 		$this->categorys = array();
 		$this->yearMonths = array();
-
 		$this->enableCache = $enableCache;
+		$this->baseurl = preg_replace('/^(http|https):\/\/[^\/]*?(\/.*)$/', '\\2', base_url(""));
 
 		//先读缓存
 		if (!$this->globalDataCacheRead()) {
@@ -500,7 +503,7 @@ class Markdown {
 
 			$siteURL = $this->urlencodeFileName($siteURL);
 			$blogId = md5($siteURL);
-			$siteURL = trim(base_url($siteURL, ""),":");
+			$siteURL = $this->baseurl.$siteURL;
 
 			$blog = array(
 				"blogId" => $blogId,
@@ -533,7 +536,7 @@ class Markdown {
 			$monthObj = array(
 				"id" => $yearMonthId,
 				"name" => $month,
-				"url" => trim(base_url("archive/" . $yearMonthId . ".html", ""),":")
+				"url" => $this->baseurl . "archive/" . $yearMonthId . ".html"
 			);
 
 			if (!$this->checkObjInArr($monthObj, "yearMonths")) {
@@ -667,7 +670,7 @@ class Markdown {
 			$tagObj = array(
 				"id" => $id,
 				"name" => $tag,
-				"url" => trim(base_url("$type/" . $id . ".html", ""),":")
+				"url" => $this->baseurl . "$type/" . $id . ".html"
 			);
 
 			array_push($tagsObjArr, $tagObj);

--- a/app/libraries/Yaml.php
+++ b/app/libraries/Yaml.php
@@ -28,6 +28,7 @@ class Yaml {
     		"mathjax" => false,
     		"katex" => false,
     		"duoshuo" => "",
+			"disqus" => "",
     		"baiduAnalytics" => "",
     		"keywords" => "GitBlog,博客,Markdown博客,jockchou",
     		"description" => "GitBlog是一个简单易用的Markdown博客系统",

--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -5,9 +5,9 @@ title           : jockchou的博客               #博客标题
 subtitle        : 自豪地采用GitBlog            #博客副标题
 theme           : quest                        #主题名称
 enableCache     : true                         #是否开启缓存
-highlight       : on                           #是否开启代码高亮支持
-mathjax         : on                           #是否开启MathJax数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
-katex           : on                           #是否开启KaTeX数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
+highlight       : true                           #是否开启代码高亮支持
+mathjax         : false                           #是否开启MathJax数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
+katex           : false                           #是否开启KaTeX数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
 duoshuo         : jockchou                     #多说评论框ID，duoshuo和disqus同时设置时，disqus优先
 disqus          : demo-site                    #DISQUS评论框 Short Site Name，XXX.disqus.com，duosuo和disqus同时设置时，disqus优先
 baiduAnalytics  : 732acc76ff6bd41343951a67cbfafe34  #百度统计ID

--- a/example-conf.yaml
+++ b/example-conf.yaml
@@ -6,9 +6,10 @@ subtitle        : 自豪地采用GitBlog            #博客副标题
 theme           : quest                        #主题名称
 enableCache     : true                         #是否开启缓存
 highlight       : on                           #是否开启代码高亮支持
-mathjax         : on                           #是否开启MathJax数学公式渲染支持，MathJax和KaTeX互斥
-katex           : on                           #是否开启KaTeX数学公式渲染支持，MathJax和KaTeX互斥
-duoshuo         : jockchou                     #多说评论框ID
+mathjax         : on                           #是否开启MathJax数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
+katex           : on                           #是否开启KaTeX数学公式渲染支持，MathJax和KaTeX同时设置时，KaTeX优先
+duoshuo         : jockchou                     #多说评论框ID，duoshuo和disqus同时设置时，disqus优先
+disqus          : demo-site                    #DISQUS评论框 Short Site Name，XXX.disqus.com，duosuo和disqus同时设置时，disqus优先
 baiduAnalytics  : 732acc76ff6bd41343951a67cbfafe34  #百度统计ID
 keywords        : jockchou,markdown,blog,php,github #网站关键字
 description     : GitBlog是一个简单易用的Markdown博客系统,这是我的第一个GitBlog博客. #网站描述

--- a/theme/beach/_layouts/base.html
+++ b/theme/beach/_layouts/base.html
@@ -6,18 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if blog %}{{ blog.title }}|{{ site.title }} {% else %}{{ site.title }}{% endif %}</title>
     
-    <meta name="keywords" content="{% if blog %}{{ blog.keywords}},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
+    <meta name="keywords" content="{% if blog %}{{ blog.keywords }},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
 	<meta name="description" content="{% if blog %}{{ blog.summary | striptags | replace({'\n': ''}) | slice(0, 140) }}{% else %}{{ site.description }}{% endif %}">
-    <link rel="stylesheet" type="text/css" href="{{site.url}}theme/beach/css/style.css?ver={{ site.version }}">
-    <link rel="stylesheet" type="text/css" href="{{site.url}}theme/beach/css/markdown.css?ver={{ site.version }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+    <link rel="stylesheet" type="text/css" href="{{ site.url }}theme/beach/css/style.css?ver={{ site.version }}">
+    <link rel="stylesheet" type="text/css" href="{{ site.url }}theme/beach/css/markdown.css?ver={{ site.version }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
     
     <!--[if IE]>
 	<script src="//cdn.bootcss.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 	<![endif]-->
 	
     <!--[if IE 6]>
-	<script src="{{site.url}}theme/beach/js/belatedPNG.js"></script>
+	<script src="{{ site.url }}theme/beach/js/belatedPNG.js"></script>
 	<script>
     	DD_belatedPNG.fix('*');
 	</script>
@@ -50,11 +50,6 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-{% endif %}
-
 {% if site.katex %}
 <link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
 <script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
@@ -73,6 +68,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/beach/detail.html
+++ b/theme/beach/detail.html
@@ -2,28 +2,48 @@
 
 {% block main %}
 <section id="main">
-    {% include "_includes/post.html" %}
-    <section id="comments">
-    {% if site.duoshuo %}
-	<div class="post-content">
-		<!-- 多说评论框 start -->
-		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
-		<!-- 多说评论框 end -->
-		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
-		<script type="text/javascript">
-		var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
-		(function() {
-			var ds = document.createElement('script');
-			ds.type = 'text/javascript';ds.async = true;
-			ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
-			ds.charset = 'UTF-8';
-			(document.getElementsByTagName('head')[0] 
-			 || document.getElementsByTagName('body')[0]).appendChild(ds);
-		})();
-		</script>
-        <!-- 多说公共JS代码 end -->
-	</div>
-	{% endif %}
-    </section>
+	{% include "_includes/post.html" %}
+	<section id="comments">
+		{% if site.disqus %}
+		<div class="post-content">
+			<div id="disqus_thread"></div>
+			<script>
+var disqus_config = function () {
+	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.identifier = '{{ blog.blogId }}';
+};
+(function() {
+	var d = document, s = d.createElement('script');
+	s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+	s.setAttribute('data-timestamp', +new Date());
+	(d.head || d.body).appendChild(s);
+})();
+			</script>
+			<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+		</div>
+		{% elseif site.duoshuo %}
+		<div class="post-content">
+			<!-- 多说评论框 start -->
+			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+			<script type="text/javascript">
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+			</script>
+			<!-- 多说评论框 end -->
+			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
+			<script type="text/javascript">
+var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
+(function() {
+	var ds = document.createElement('script');
+	ds.type = 'text/javascript';ds.async = true;
+	ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
+	ds.charset = 'UTF-8';
+	(document.getElementsByTagName('head')[0] 
+	 || document.getElementsByTagName('body')[0]).appendChild(ds);
+})();
+			</script>
+			<!-- 多说公共JS代码 end -->
+		</div>
+		{% endif %}
+	</section>
 </section>
 {% endblock %}

--- a/theme/beach/detail.html
+++ b/theme/beach/detail.html
@@ -9,7 +9,7 @@
 			<div id="disqus_thread"></div>
 			<script>
 var disqus_config = function () {
-	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.url = location.href;
 	this.page.identifier = '{{ blog.blogId }}';
 };
 (function() {
@@ -26,7 +26,7 @@ var disqus_config = function () {
 			<!-- 多说评论框 start -->
 			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 			<script type="text/javascript">
-document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', location.href);
 			</script>
 			<!-- 多说评论框 end -->
 			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/cube/_includes/detailcontent.html
+++ b/theme/cube/_includes/detailcontent.html
@@ -19,7 +19,7 @@
 			<div id="disqus_thread"></div>
 			<script>
 var disqus_config = function () {
-	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.url = location.href;
 	this.page.identifier = '{{ blog.blogId }}';
 };
 (function() {
@@ -36,7 +36,7 @@ var disqus_config = function () {
 			<!-- 多说评论框 start -->
 			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 			<script type="text/javascript">
-document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url',  location.href);
 			</script>
 			<!-- 多说评论框 end -->
 			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/cube/_includes/detailcontent.html
+++ b/theme/cube/_includes/detailcontent.html
@@ -1,41 +1,67 @@
 <div class="container">
-    <span class="content-title">{{ blog.title }}</span>
-    <div class="content">
-        <article class="full">
-            <div class="read">
-                <div class="post">
-                    <h2>{{ blog.title }}</h2>
-                    <p>
-                    	{{ blog.content | raw }}
-                    </p>
-                </div>
-                <div class="meta">
-                    <span>{{ blog.date | date('Y-m-d') }} {{ blog.author }}</span>
-                </div>
-            </div>
-        </article>
-        {% if site.duoshuo %}
+	<span class="content-title">{{ blog.title }}</span>
+	<div class="content">
+		<article class="full">
+			<div class="read">
+				<div class="post">
+					<h2>{{ blog.title }}</h2>
+					<p>
+					{{ blog.content | raw }}
+					</p>
+				</div>
+				<div class="meta">
+					<span>{{ blog.date | date('Y-m-d') }} {{ blog.author }}</span>
+				</div>
+			</div>
+		</article>
+		{% if site.disqus %}
+		<div class="post-content">
+			<div id="disqus_thread"></div>
+			<script>
+var disqus_config = function () {
+	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.identifier = '{{ blog.blogId }}';
+};
+(function() {
+	var d = document, s = d.createElement('script');
+	s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+	s.setAttribute('data-timestamp', +new Date());
+	(d.head || d.body).appendChild(s);
+})();
+			</script>
+			<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+		</div>
+		{% elseif site.duoshuo %}
 		<div class="post-content">
 			<!-- 多说评论框 start -->
-			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
+			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+			<script type="text/javascript">
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+			</script>
 			<!-- 多说评论框 end -->
 			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 			<script type="text/javascript">
-			var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
-			(function() {
-				var ds = document.createElement('script');
-				ds.type = 'text/javascript';ds.async = true;
-				ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
-				ds.charset = 'UTF-8';
-				(document.getElementsByTagName('head')[0] 
-				 || document.getElementsByTagName('body')[0]).appendChild(ds);
-			})();
+var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
+(function() {
+	var ds = document.createElement('script');
+	ds.type = 'text/javascript';ds.async = true;
+	ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
+	ds.charset = 'UTF-8';
+	(document.getElementsByTagName('head')[0] 
+	 || document.getElementsByTagName('body')[0]).appendChild(ds);
+})();
 			</script>
-	        <!-- 多说公共JS代码 end -->
+			<!-- 多说公共JS代码 end -->
 		</div>
 		{% endif %}
-    </div>
-    <div id="duoshuo"></div>
+	</div>
+	<div id="{% if site.disqus %}
+	disqus
+	{% elseif site.duosuo %}
+	duoshuo
+	{% else %}
+	comment
+	{% endif %}"></div>
 </div>
 
 {% include "_includes/footer.html" %}

--- a/theme/cube/_includes/head.html
+++ b/theme/cube/_includes/head.html
@@ -1,13 +1,13 @@
 <head>
 	<meta charset="utf-8">
 	<title>{% if blog %}{{ blog.title }}|{{ site.title }} {% else %}{{ site.title }}{% endif %}</title>
-	<meta name="keywords" content="{% if blog %}{{ blog.keywords}},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
+	<meta name="keywords" content="{% if blog %}{{ blog.keywords }},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
 	<meta name="description" content="{% if blog %}{{ blog.summary | striptags | replace({'\n': ''}) | slice(0, 140) }}{% else %}{{ site.description }}{% endif %}">
-	<link rel="stylesheet" href="{{site.url}}theme/cube/css/font-awesome.min.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/cube/css/style.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/cube/css/style-mobile.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/cube/css/main.css?ver={{ site.version }}">
-	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+	<link rel="stylesheet" href="{{ site.url }}theme/cube/css/font-awesome.min.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/cube/css/style.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/cube/css/style-mobile.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/cube/css/main.css?ver={{ site.version }}">
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
     <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900" rel="stylesheet" type="text/css">
     
 	{% if site.baiduAnalytics %}<script>

--- a/theme/cube/_includes/posts.html
+++ b/theme/cube/_includes/posts.html
@@ -2,28 +2,34 @@
 <article>
 	{% if blog.images %}
 	<div class="look" style="background-image: url('{{ blog.images.0 }}');">
-    	<a href="{{ blog.siteURL }}" title="{{ blog.title }}"><!-- {{ blog.title }} --></a>
-    </div>
-    {% endif %}
+		<a href="{{ blog.siteURL }}" title="{{ blog.title }}"><!-- {{ blog.title }} --></a>
+	</div>
+	{% endif %}
 
-    <div class="read">
-    	{% if blog.images %}
-        <div class="excerpt">
-        {% else %}
-        <div class="excerpt" style="height:343px;">
-        {% endif %}
-            <h2><a href="{{ blog.siteURL }}" title="{{ blog.title }}">{{ blog.title }}</a></h2>
-            <p></p>
-            <p>{{ blog.summary | raw }}</p>
-            <p></p>
-        </div>
+	<div class="read">
+		{% if blog.images %}
+		<div class="excerpt">
+			{% else %}
+			<div class="excerpt" style="height:343px;">
+				{% endif %}
+				<h2><a href="{{ blog.siteURL }}" title="{{ blog.title }}">{{ blog.title }}</a></h2>
+				<p></p>
+				<p>{{ blog.summary | raw }}</p>
+				<p></p>
+			</div>
 
-        <div class="meta">
-            <span>{{ blog.date | date("Y-m-d")}}</span>
-            <div class="share">
-                <a class="facebook fa fa-paper-plane" href="{{ blog.siteURL }}#duoshuo" title="add comment"></a>
-            </div>
-        </div>
-    </div>
+			<div class="meta">
+				<span>{{ blog.date | date("Y-m-d")}}</span>
+				<div class="share">
+					<a class="facebook fa fa-paper-plane" href="{{ blog.siteURL }}#{% if confObj.duoshuo %}
+					duoshuo
+					{% elseif confObj.disqus %}
+					disqus
+					{% else %}
+					comment
+					{% endif %}" title="add comment"></a>
+				</div>
+			</div>
+		</div>
 </article>
 {% endfor %}

--- a/theme/cube/_layouts/default.html
+++ b/theme/cube/_layouts/default.html
@@ -10,11 +10,6 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-{% endif %}
-
 {% if site.katex %}
 <link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
 <script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
@@ -33,6 +28,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/default/block/base.html
+++ b/theme/default/block/base.html
@@ -4,35 +4,35 @@
 {% block head %}
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
-	<meta name="keywords" content="{% block keywords %}{{ confObj.keywords }},{{ confObj.title }}{% endblock %}">
-	<meta name="description" content="{% block description %}{{ confObj.description }}{% endblock %}">
+	<meta name="keywords" content="{% block keywords %}{{ site.keywords }},{{ site.title }}{% endblock %}">
+	<meta name="description" content="{% block description %}{{ site.description }}{% endblock %}">
 
 	<!--[if lt IE 9]>
-	<script src="{{site.url}}theme/default/js/html5.js"></script>
+	<script src="{{ site.url }}theme/default/js/html5.js"></script>
 	<![endif]-->
 	<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>
 	
-	<title>{% block title %}{{ confObj.title }}{% endblock %}</title>
+	<title>{% block title %}{{ site.title }}{% endblock %}</title>
 	
-	<link rel="stylesheet" href="{{site.url}}theme/default/css/genericons.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="{{site.url}}theme/default/css/style.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="{{site.url}}theme/default/css/markdown.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+	<link rel="stylesheet" href="{{ site.url }}theme/default/css/genericons.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/default/css/style.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/default/css/markdown.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
 	<!--[if lt IE 9]>
-	<link rel="stylesheet" href="{{site.url}}theme/default/css/ie.css?ver={{ confObj.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/default/css/ie.css?ver={{ site.version }}" type="text/css" media="all" />
 	<![endif]-->
 	<!--[if lt IE 8]>
-	<link rel="stylesheet" href="{{site.url}}theme/default/css/ie7.css?ver={{ confObj.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/default/css/ie7.css?ver={{ site.version }}" type="text/css" media="all" />
 	<![endif]-->
 	
-	<script type="text/javascript" src="{{site.url}}theme/default/js/jquery/jquery.js?ver={{ confObj.version }}"></script>
-	<script type="text/javascript" src="{{site.url}}theme/default/js/jquery/jquery-migrate.min.js?ver={{ confObj.version }}"></script>
+	<script type="text/javascript" src="{{ site.url }}theme/default/js/jquery/jquery.js?ver={{ site.version }}"></script>
+	<script type="text/javascript" src="{{ site.url }}theme/default/js/jquery/jquery-migrate.min.js?ver={{ site.version }}"></script>
 	
-	{% if confObj.baiduAnalytics %}<script>
+	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];
 	(function() {
 	  var hm = document.createElement("script");
-	  hm.src = "//hm.baidu.com/hm.js?{{ confObj.baiduAnalytics }}";
+	  hm.src = "//hm.baidu.com/hm.js?{{ site.baiduAnalytics }}";
 	  var s = document.getElementsByTagName("script")[0]; 
 	  s.parentNode.insertBefore(hm, s);
 	})();
@@ -59,11 +59,6 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-{% endif %}
-
 {% if site.katex %}
 <link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
 <script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
@@ -82,6 +77,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/default/block/comments.html
+++ b/theme/default/block/comments.html
@@ -4,7 +4,7 @@
 		<div id="disqus_thread"></div>
 		<script>
 		   var disqus_config = function () {
-		   this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+		   this.page.url = location.href;
 		   this.page.identifier = '{{ blog.blogId }}';
 		   };
 		(function() {
@@ -23,7 +23,7 @@
 		<!-- 多说评论框 start -->
 		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 		<script type="text/javascript">
-		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', location.href);
 		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/default/block/comments.html
+++ b/theme/default/block/comments.html
@@ -1,12 +1,34 @@
-{% if confObj.duoshuo %}
+{% if site.disqus %}
+<div id="comments" class="comments-area">
+	<div id="respond" class="comment-respond">
+		<div id="disqus_thread"></div>
+		<script>
+		   var disqus_config = function () {
+		   this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+		   this.page.identifier = '{{ blog.blogId }}';
+		   };
+		(function() {
+			var d = document, s = d.createElement('script');
+			s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+			s.setAttribute('data-timestamp', +new Date());
+			(d.head || d.body).appendChild(s);
+		})();
+		</script>
+		<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+	</div><!-- #respond -->
+</div><!-- .comments-area -->
+{% elseif site.duoshuo %}
 <div id="comments" class="comments-area">
 	<div id="respond" class="comment-respond">
 		<!-- 多说评论框 start -->
-		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
+		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+		<script type="text/javascript">
+		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 		<script type="text/javascript">
-		var duoshuoQuery = {short_name:"{{ confObj.duoshuo }}"};
+		var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
 		(function() {
 			var ds = document.createElement('script');
 			ds.type = 'text/javascript';ds.async = true;

--- a/theme/default/block/script.html
+++ b/theme/default/block/script.html
@@ -1,7 +1,7 @@
-<script type="text/javascript" src="{{site.url}}theme/default/js/skip-link-focus-fix.js?ver={{ confObj.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/default/js/skip-link-focus-fix.js?ver={{ site.version }}"></script>
 <script type="text/javascript">
 /* <![CDATA[ */
 var screenReaderText = {"expand":"<span class=\"screen-reader-text\">\u5c55\u5f00\u5b50\u83dc\u5355<\/span>","collapse":"<span class=\"screen-reader-text\">\u6298\u53e0\u5b50\u83dc\u5355<\/span>"};
 /* ]]> */
 </script>
-<script type="text/javascript" src="{{site.url}}theme/default/js/functions.js?ver={{ confObj.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/default/js/functions.js?ver={{ site.version }}"></script>

--- a/theme/default/block/sidebar.html
+++ b/theme/default/block/sidebar.html
@@ -1,8 +1,8 @@
 <div id="sidebar" class="sidebar">
 	<header id="masthead" class="site-header" role="banner">
 		<div class="site-branding">
-			<h1 class="site-title"><a href="{{ confObj.url }}" rel="home">{{ confObj.title }}</a></h1>
-				<p class="site-description">{{ confObj.subtitle }}</p>
+			<h1 class="site-title"><a href="{{ site.url }}" rel="home">{{ site.title }}</a></h1>
+				<p class="site-description">{{ site.subtitle }}</p>
 				<button class="secondary-toggle">菜单和挂件</button>
 		</div><!-- .site-branding -->
 	</header><!-- .site-header -->

--- a/theme/default/blog/header.html
+++ b/theme/default/blog/header.html
@@ -1,9 +1,9 @@
 {% if pageName != "blog" %}
 <header class="entry-header">
-	<h2 class="entry-title"><a href="{{ blog.siteURL}}" rel="bookmark">{{ blog.title}}</a></h2>
+	<h2 class="entry-title"><a href="{{ blog.siteURL }}" rel="bookmark">{{ blog.title }}</a></h2>
 </header><!-- .entry-header -->
 {% else %}
 <header class="entry-header">
-    <h1 class="entry-title">{{ blog.title}}</h1>
+    <h1 class="entry-title">{{ blog.title }}</h1>
 </header><!-- .entry-header -->
 {% endif %}

--- a/theme/default/detail.html
+++ b/theme/default/detail.html
@@ -1,8 +1,8 @@
 {% extends "block/base.html" %}
 
-{% block title %}{{ blog.title }}|{{ confObj.title }}{% endblock %}
+{% block title %}{{ blog.title }}|{{ site.title }}{% endblock %}
 
-{% block keywords %}{{ blog.keywords }},{{ confObj.title }}{% endblock %}
+{% block keywords %}{{ blog.keywords }},{{ site.title }}{% endblock %}
 
 {% block description %}{{ blog.summary | replace({'\n': ''}) | striptags | slice(0, 140) }}{% endblock %}
 

--- a/theme/default/widget/text.html
+++ b/theme/default/widget/text.html
@@ -1,8 +1,8 @@
-{% if attribute(confObj.text, "intro") %}
+{% if attribute(site.text, "intro") %}
 <aside id="text" class="widget widget_text">
-    <h2 class="widget-title">{{ confObj.text.title }}</h2>	
+    <h2 class="widget-title">{{ site.text.title }}</h2>	
     <div class="textwidget">
-    	<p>{{ confObj.text.intro }}</p>
+    	<p>{{ site.text.intro }}</p>
     </div>
 </aside>
 {% endif %}

--- a/theme/line/404.html
+++ b/theme/line/404.html
@@ -3,7 +3,7 @@
 {% block content %}
 	<article class="single">
     <div class="row">
-		{% set headUrl = "{{site.url}}blog/img/logo_64x64.png" %}
+		{% set headUrl = "{{ site.url }}blog/img/logo_64x64.png" %}
         	{% if site.author.avatar %}
         		{% set headUrl = site.author.avatar %}
         	{% endif %}

--- a/theme/line/_includes/head.html
+++ b/theme/line/_includes/head.html
@@ -4,11 +4,11 @@
 	<title>{% if blog %}{{ blog.title }}|{{ site.title }} {% else %}{{ site.title }}{% endif %}</title>
 	<meta name="keywords" content="{% if blog %}{{ blog.keywords}},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
 	<meta name="description" content="{% if blog %}{{ blog.summary | striptags | replace({'\n': ''}) | slice(0, 140) }}{% else %}{{ site.description }}{% endif %}">
-	<link rel="stylesheet" href="{{site.url}}theme/line/css/font-awesome.min.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/line/css/main.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/line/css/style.css?ver={{ site.version }}">
-	<link rel="stylesheet" href="{{site.url}}theme/line/css/markdown.css?ver={{ site.version }}">
-	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+	<link rel="stylesheet" href="{{ site.url }}theme/line/css/font-awesome.min.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/line/css/main.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/line/css/style.css?ver={{ site.version }}">
+	<link rel="stylesheet" href="{{ site.url }}theme/line/css/markdown.css?ver={{ site.version }}">
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
     
 	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];

--- a/theme/line/_includes/posts.html
+++ b/theme/line/_includes/posts.html
@@ -2,7 +2,7 @@
 <article class="published">
     <div class="row">
         <div class="one-quarter meta">
-			{% set headUrl = "{{site.url}}blog/img/logo_64x64.png" %}
+			{% set headUrl = "{{ site.url }}blog/img/logo_64x64.png" %}
         	{% if blog.head %}
         		{% set headUrl = blog.head %}
         	{% endif %}

--- a/theme/line/_layouts/default.html
+++ b/theme/line/_layouts/default.html
@@ -10,11 +10,6 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-{% endif %}
-
 {% if site.katex %}
 <link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
 <script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
@@ -33,6 +28,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/line/detail.html
+++ b/theme/line/detail.html
@@ -1,55 +1,73 @@
 {% extends "_layouts/default.html" %}
 {% block content %}
 <a title="首页" class="fa fa-paper-plane dp-dropplets-icon" href="{{ site.url }}"></a>
-	<article class="single ">
-    <div class="row">
-        <div class="one-quarter meta">
-            <div class="thumbnail">
-				{% set headUrl = "{{site.url}}blog/img/logo_64x64.png" %}
-        	{% if blog.authorHead %}
-        		{% set headUrl = blog.authorHead %}
-        	{% endif %}
-                <img src="{{ headUrl }}" alt="{{ blog.author }}" />
-            </div>
+<article class="single ">
+	<div class="row">
+		<div class="one-quarter meta">
+			<div class="thumbnail">
+				{% set headUrl = "{{ site.url }}blog/img/logo_64x64.png" %}
+				{% if blog.authorHead %}
+				{% set headUrl = blog.authorHead %}
+				{% endif %}
+				<img src="{{ headUrl }}" alt="{{ blog.author }}" />
+			</div>
 
-            <ul>
-                <li>{{ blog.author }}</li>
-                <li>{{ blog.date | date("Y-m-d")}}</li>
-                <li>
-                {% if attribute(blog.category, 0) %}
-                {% for category in blog.category %}  
-			    <a href="{{ category.url }}">{{ category.name }}</a>
-			    {% endfor %}
-			    {% endif %}
-                </li>
-                <li></li>
-            </ul>
-        </div>
+			<ul>
+				<li>{{ blog.author }}</li>
+				<li>{{ blog.date | date("Y-m-d")}}</li>
+				<li>
+					{% if attribute(blog.category, 0) %}
+					{% for category in blog.category %}  
+					<a href="{{ category.url }}">{{ category.name }}</a>
+					{% endfor %}
+					{% endif %}
+				</li>
+				<li></li>
+			</ul>
+		</div>
 
-        <div class="three-quarters post">
-            <h2>{{ blog.title }}</h2>
-            {{ blog.content | raw }}
-            
-            <br/>
-        	{% if site.duoshuo %}
+		<div class="three-quarters post">
+			<h2>{{ blog.title }}</h2>
+			{{ blog.content | raw }}
+
+			<br/>
+			{% if site.disqus %}
+			<div id="disqus_thread"></div>
+			<script>
+var disqus_config = function () {
+	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.identifier = '{{ blog.blogId }}';
+};
+(function() {
+	var d = document, s = d.createElement('script');
+	s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+	s.setAttribute('data-timestamp', +new Date());
+	(d.head || d.body).appendChild(s);
+})();
+			</script>
+			<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+			{% elseif site.duoshuo %}
 			<!-- 多说评论框 start -->
-			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
+			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+			<script type="text/javascript">
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+			</script>
 			<!-- 多说评论框 end -->
 			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 			<script type="text/javascript">
-			var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
-			(function() {
-				var ds = document.createElement('script');
-				ds.type = 'text/javascript';ds.async = true;
-				ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
-				ds.charset = 'UTF-8';
-				(document.getElementsByTagName('head')[0] 
-				 || document.getElementsByTagName('body')[0]).appendChild(ds);
-			})();
+var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
+(function() {
+	var ds = document.createElement('script');
+	ds.type = 'text/javascript';ds.async = true;
+	ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
+	ds.charset = 'UTF-8';
+	(document.getElementsByTagName('head')[0] 
+	 || document.getElementsByTagName('body')[0]).appendChild(ds);
+})();
 			</script>
-	        <!-- 多说公共JS代码 end -->
+			<!-- 多说公共JS代码 end -->
+			{% endif %}
 		</div>
-		{% endif %}
-    </div>
+	</div>
 </article>	
 {% endblock %}

--- a/theme/line/detail.html
+++ b/theme/line/detail.html
@@ -35,7 +35,7 @@
 			<div id="disqus_thread"></div>
 			<script>
 var disqus_config = function () {
-	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.url = location.href;
 	this.page.identifier = '{{ blog.blogId }}';
 };
 (function() {
@@ -50,7 +50,7 @@ var disqus_config = function () {
 			<!-- 多说评论框 start -->
 			<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 			<script type="text/javascript">
-document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', location.href);
 			</script>
 			<!-- 多说评论框 end -->
 			<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/quest/block/base.html
+++ b/theme/quest/block/base.html
@@ -4,22 +4,22 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>{% block title %}{{ confObj.title }}{% endblock %}</title>
-	<meta name="keywords" content="{% block keywords %}{{ confObj.keywords }},{{ confObj.title }}{% endblock %}">
-	<meta name="description" content="{% block description %}{{ confObj.description }}{% endblock %}">
+	<title>{% block title %}{{ site.title }}{% endblock %}</title>
+	<meta name="keywords" content="{% block keywords %}{{ site.keywords }},{{ site.title }}{% endblock %}">
+	<meta name="description" content="{% block description %}{{ site.description }}{% endblock %}">
 	
-	<link rel="stylesheet" href="{{site.url}}theme/quest/assets/plugins/bootstrap/css/bootstrap.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="{{site.url}}theme/quest/assets/plugins/font-awesome/css/font-awesome.min.css?ver={{ confObj.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/quest/assets/plugins/bootstrap/css/bootstrap.min.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/quest/assets/plugins/font-awesome/css/font-awesome.min.css?ver={{ site.version }}" type="text/css" media="all" />
 	<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600&subset=latin,latin-ext">
-	<link rel="stylesheet" href="{{site.url}}theme/quest/css/style.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="stylesheet" href="{{site.url}}theme/quest/css/customizer.css?ver={{ confObj.version }}" type="text/css" media="all" />
-	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+	<link rel="stylesheet" href="{{ site.url }}theme/quest/css/style.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="stylesheet" href="{{ site.url }}theme/quest/css/customizer.css?ver={{ site.version }}" type="text/css" media="all" />
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
 	
-	{% if confObj.baiduAnalytics %}<script>
+	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];
 	(function() {
 	  var hm = document.createElement("script");
-	  hm.src = "//hm.baidu.com/hm.js?{{ confObj.baiduAnalytics }}";
+	  hm.src = "//hm.baidu.com/hm.js?{{ site.baiduAnalytics }}";
 	  var s = document.getElementsByTagName("script")[0]; 
 	  s.parentNode.insertBefore(hm, s);
 	})();
@@ -37,24 +37,18 @@
 	</div><!-- #page -->
 	<a href="#0" class="cd-top"><i class="fa fa-angle-up"></i></a>
 
-
-<script type="text/javascript" src="{{site.url}}theme/quest/assets/plugins/modernizr/modernizr.custom.js?ver={{ confObj.version }}"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/js/jquery/jquery.js?ver=1.11.2"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/js/jquery/jquery-migrate.min.js?ver=1.2.1"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/assets/plugins/bootstrap/js/bootstrap.min.js?ver={{ confObj.version }}"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/assets/plugins/wow/wow.js?ver={{ confObj.version }}"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/assets/plugins/colorbox/jquery.colorbox-min.js?ver={{ confObj.version }}"></script>
-<script type="text/javascript" src="{{site.url}}theme/quest/assets/js/quest.js?ver={{ confObj.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/assets/plugins/modernizr/modernizr.custom.js?ver={{ site.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/js/jquery/jquery.js?ver=1.11.2"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/js/jquery/jquery-migrate.min.js?ver=1.2.1"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/assets/plugins/bootstrap/js/bootstrap.min.js?ver={{ site.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/assets/plugins/wow/wow.js?ver={{ site.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/assets/plugins/colorbox/jquery.colorbox-min.js?ver={{ site.version }}"></script>
+<script type="text/javascript" src="{{ site.url }}theme/quest/assets/js/quest.js?ver={{ site.version }}"></script>
 	
 {% if site.highlight %}
 <link rel="stylesheet" href="//cdn.bootcss.com/highlight.js/8.6/styles/default.min.css">
 <script src="//cdn.bootcss.com/highlight.js/8.6/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-{% endif %}
-
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
 
 {% if site.katex %}
@@ -75,6 +69,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/quest/block/breadcrumbs.html
+++ b/theme/quest/block/breadcrumbs.html
@@ -10,7 +10,7 @@
 			</div>
 			<div class="col-md-6">
 				<ul class="breadcrumbs">
-					<li><a href="{{site.url}}">Home</a></li>
+					<li><a href="{{ site.url }}">Home</a></li>
 					{% if pageName == "search" %}
 					<li>search</li>
 					{% else%}

--- a/theme/quest/block/comments.html
+++ b/theme/quest/block/comments.html
@@ -4,7 +4,7 @@
 		<div id="disqus_thread"></div>
 		<script>
 		   var disqus_config = function () {
-		   this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+		   this.page.url = location.href;
 		   this.page.identifier = '{{ blog.blogId }}';
 		   };
 		(function() {
@@ -23,7 +23,7 @@
 		<!-- 多说评论框 start -->
 		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 		<script type="text/javascript">
-		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', location.href);
 		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/quest/block/comments.html
+++ b/theme/quest/block/comments.html
@@ -1,12 +1,34 @@
-{% if confObj.duoshuo %}
+{% if site.disqus %}
+<div id="comments" class="clearfix">
+	<div id="respond" class="comment-respond">
+		<div id="disqus_thread"></div>
+		<script>
+		   var disqus_config = function () {
+		   this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+		   this.page.identifier = '{{ blog.blogId }}';
+		   };
+		(function() {
+			var d = document, s = d.createElement('script');
+			s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+			s.setAttribute('data-timestamp', +new Date());
+			(d.head || d.body).appendChild(s);
+		})();
+		</script>
+		<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+	</div><!-- #respond -->
+</div>
+{% elseif site.duoshuo %}
 <div id="comments" class="clearfix">
 	<div id="respond" class="comment-respond">
 		<!-- 多说评论框 start -->
-		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
+		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+		<script type="text/javascript">
+		document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 		<script type="text/javascript">
-		var duoshuoQuery = {short_name:"{{ confObj.duoshuo }}"};
+		var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
 		(function() {
 			var ds = document.createElement('script');
 			ds.type = 'text/javascript';ds.async = true;

--- a/theme/quest/block/header.html
+++ b/theme/quest/block/header.html
@@ -2,8 +2,8 @@
 <div class="container">
 	<div class="row">
 		<div class="site-branding col-md-4">
-			<h1 class="site-title"><a href="{{ confObj.url }}" rel="home">{{ confObj.title }}</a></h1>
-				<span class="site-description">{{ confObj.subtitle }}</span>
+			<h1 class="site-title"><a href="{{ site.url }}" rel="home">{{ site.title }}</a></h1>
+				<span class="site-description">{{ site.subtitle }}</span>
 		</div>
 		<!-- .site-branding -->
 	</div>

--- a/theme/quest/blog/header.html
+++ b/theme/quest/blog/header.html
@@ -1,5 +1,5 @@
 <header class="entry-header">
-	<h1 class="post-title"><a href="{{ blog.siteURL}}" rel="bookmark">{{ blog.title}} {% if blog.top != 0 %}<span class="top">[置顶]</span>{% endif %}</a></h1>
+	<h1 class="post-title"><a href="{{ blog.siteURL }}" rel="bookmark">{{ blog.title }} {% if blog.top != 0 %}<span class="top">[置顶]</span>{% endif %}</a></h1>
 	<div class="entry-meta">
 		<time class="post-date"><i class="fa fa-clock-o"></i>{{ blog.date}}</time>
 		{% if blog.author %}

--- a/theme/quest/detail.html
+++ b/theme/quest/detail.html
@@ -1,8 +1,8 @@
 {% extends "block/base.html" %}
 
-{% block title %}{{ blog.title }}|{{ confObj.title }}{% endblock %}
+{% block title %}{{ blog.title }}|{{ site.title }}{% endblock %}
 
-{% block keywords %}{{ blog.keywords }},{{ confObj.title }}{% endblock %}
+{% block keywords %}{{ blog.keywords }},{{ site.title }}{% endblock %}
 
 {% block description %}{{ blog.summary | replace({'\n': ''}) | striptags | slice(0, 140) }}{% endblock %}
 

--- a/theme/quest/widget/search.html
+++ b/theme/quest/widget/search.html
@@ -1,6 +1,6 @@
 <aside class="widget widget_search sidebar-widget clearfix">
 	<h3 class="widget-title">搜索</h3>
-	<form class="search" action="{{site.url}}search" method="get">
+	<form class="search" action="{{ site.url }}search" method="get">
 		<fieldset>
 			<div class="text">
 				<input name="keyword" id="keyword" type="text" placeholder="Search ..."/>

--- a/theme/quest/widget/text.html
+++ b/theme/quest/widget/text.html
@@ -1,8 +1,8 @@
-{% if attribute(confObj.text, "intro") %}
+{% if attribute(site.text, "intro") %}
 <aside class="widget widget_text sidebar-widget clearfix">
-	<h3 class="widget-title">{{ confObj.text.title }}</h3>
+	<h3 class="widget-title">{{ site.text.title }}</h3>
 	<div class="textwidget">
-		<p>{{ confObj.text.intro }}</p>
+		<p>{{ site.text.intro }}</p>
 	</div>
 </aside>
 {% endif %}

--- a/theme/simple/_includes/head.html
+++ b/theme/simple/_includes/head.html
@@ -5,8 +5,8 @@
 	<title>{% if blog %}{{ blog.title }}|{{ site.title }} {% else %}{{ site.title }}{% endif %}</title>
 	<meta name="keywords" content="{% if blog %}{{ blog.keywords}},{{ site.keywords }}{% else %}{{ site.keywords }}{% endif %}">
 	<meta name="description" content="{% if blog %}{{ blog.summary | striptags | replace({'\n': ''}) | slice(0, 140) }}{% else %}{{ site.description }}{% endif %}">
-	<link rel="stylesheet" href="{{site.url}}theme/simple/css/main.css?ver={{ site.version }}">
-	<link rel="alternate" type="application/rss+xml" title="{{ confObj.title }}" href="{{ confObj.url }}/feed.xml" />
+	<link rel="stylesheet" href="{{ site.url }}theme/simple/css/main.css?ver={{ site.version }}">
+	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}feed.xml" />
 	
 	{% if site.baiduAnalytics %}<script>
 	var _hmt = _hmt || [];

--- a/theme/simple/_includes/header.html
+++ b/theme/simple/_includes/header.html
@@ -1,5 +1,5 @@
 <header class="site-header">
 	<div class="wrapper">
-		<a class="site-title" href="{{ confObj.url }}">{{ confObj.title }}</a>
+		<a class="site-title" href="{{ site.url }}">{{ site.title }}</a>
 	</div>
 </header>

--- a/theme/simple/_layouts/default.html
+++ b/theme/simple/_layouts/default.html
@@ -16,11 +16,6 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {% endif %}
 
-{% if site.mathjax %}
-<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
-<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-{% endif %}
-
 {% if site.katex %}
 <link rel="stylesheet" href="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.css">
 <script src="//cdn.bootcss.com/KaTeX/0.6.0/katex.min.js"></script>
@@ -39,6 +34,10 @@ render_option = {
 }
 renderMathInElement(document.body, render_option);
 </script>
+{% elseif site.mathjax %}
+<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+<script type="text/javascript" src="//cdn.bootcss.com/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}
+
 </body>
 </html>

--- a/theme/simple/detail.html
+++ b/theme/simple/detail.html
@@ -15,7 +15,7 @@
 		<div id="disqus_thread"></div>
 		<script>
 var disqus_config = function () {
-	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.url = location.href;
 	this.page.identifier = '{{ blog.blogId }}';
 };
 (function() {
@@ -32,7 +32,7 @@ var disqus_config = function () {
 		<!-- 多说评论框 start -->
 		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
 		<script type="text/javascript">
-document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', location.href);
 		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->

--- a/theme/simple/detail.html
+++ b/theme/simple/detail.html
@@ -9,25 +9,45 @@
 	<article class="post-content">
 		{{ blog.content | raw }}
 	</article>
-	
-	{% if site.duoshuo %}
+
+	{% if site.disqus %}
+	<div class="post-content">
+		<div id="disqus_thread"></div>
+		<script>
+var disqus_config = function () {
+	this.page.url = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}';
+	this.page.identifier = '{{ blog.blogId }}';
+};
+(function() {
+	var d = document, s = d.createElement('script');
+	s.src = '//{{ site.disqus }}.disqus.com/embed.js';
+	s.setAttribute('data-timestamp', +new Date());
+	(d.head || d.body).appendChild(s);
+})();
+		</script>
+		<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+	</div>
+	{% elseif site.duoshuo %}
 	<div class="post-content">
 		<!-- 多说评论框 start -->
-		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url="{{ site.url }}{{ blog.siteURL }}"></div>
+		<div class="ds-thread" data-thread-key="{{ blog.blogId }}" data-title="{{ blog.title }}" data-url=""></div>
+		<script type="text/javascript">
+document.getElementsByClassName("ds-thread")[0].setAttribute('data-url', (document.location.protocol == 'https:' ? 'https:' : 'http:') + '{{ blog.siteURL }}');
+		</script>
 		<!-- 多说评论框 end -->
 		<!-- 多说公共JS代码 start (一个网页只需插入一次) -->
 		<script type="text/javascript">
-		var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
-		(function() {
-			var ds = document.createElement('script');
-			ds.type = 'text/javascript';ds.async = true;
-			ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
-			ds.charset = 'UTF-8';
-			(document.getElementsByTagName('head')[0] 
-			 || document.getElementsByTagName('body')[0]).appendChild(ds);
-		})();
+var duoshuoQuery = {short_name:"{{ site.duoshuo }}"};
+(function() {
+	var ds = document.createElement('script');
+	ds.type = 'text/javascript';ds.async = true;
+	ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
+	ds.charset = 'UTF-8';
+	(document.getElementsByTagName('head')[0] 
+	 || document.getElementsByTagName('body')[0]).appendChild(ds);
+})();
 		</script>
-        <!-- 多说公共JS代码 end -->
+		<!-- 多说公共JS代码 end -->
 	</div>
 	{% endif %}
 </div>

--- a/theme/simple/index.html
+++ b/theme/simple/index.html
@@ -14,7 +14,7 @@
 		{% endif %}
 		{% endfor %}
 	</ul>
-	<p class="rss-subscribe">subscribe <a href="{{site.url}}feed.xml">via RSS</a></p>
+	<p class="rss-subscribe">subscribe <a href="{{ site.url }}feed.xml">via RSS</a></p>
 	{% endif %}
 	
 	


### PR DESCRIPTION
* 修复多说文章列表 URL 紊乱，
* 添加 disqus 评论框支持，
* 将 theme 下 {{ confObj.xxx }} 与 {{ site.xxx }} 统一为 {{ site.xxx }}，
* 在 KaTeX 和 MathJax 中优先选择 KaTeX，
* 在 多说 和 disqus 中优先选择 disqus，
* 修复 simple line 主题中的一些 bug。